### PR TITLE
Fix api start test

### DIFF
--- a/api/client/start_test.go
+++ b/api/client/start_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/mesg-foundation/core/service"
 	"github.com/stvp/assert"
@@ -23,11 +22,6 @@ func TestStartService(t *testing.T) {
 	reply, err := serverstart.StartService(context.Background(), &StartServiceRequest{
 		Service: &service,
 	})
-	// TODO: Remove this sleep
-	// Sleep added because the test are failling, probably a concurrence issue between
-	// the test and the docker api. On a local machine it works fine but maybe the CI
-	// have some delay when starting docker
-	time.Sleep(2 * time.Second)
 	assert.Nil(t, err)
 	assert.True(t, service.IsRunning())
 	assert.NotNil(t, reply)

--- a/service/dependency_test.go
+++ b/service/dependency_test.go
@@ -3,18 +3,10 @@ package service
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/stvp/assert"
 )
-
-// TODO: this shouldn't be necessary
-func TestMain(m *testing.M) {
-	// This is to initialize the swarm if needed
-	dockerCli()
-	time.Sleep(1 * time.Second)
-}
 
 func TestExtractPortEmpty(t *testing.T) {
 	ports := extractPorts(&Dependency{})

--- a/service/docker.go
+++ b/service/docker.go
@@ -18,8 +18,8 @@ func dockerCli() (client *docker.Client, err error) {
 		client = dockerCliInstance
 		return
 	}
-	// mu.Lock()
-	// defer mu.Unlock()
+	mu.Lock()
+	defer mu.Unlock()
 	client, err = createDockerCli()
 	if err != nil {
 		return nil, err

--- a/service/docker.go
+++ b/service/docker.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/docker/docker/api/types/swarm"
 	docker "github.com/fsouza/go-dockerclient"
@@ -10,12 +11,15 @@ import (
 )
 
 var dockerCliInstance *docker.Client
+var mu sync.Mutex
 
 func dockerCli() (client *docker.Client, err error) {
 	if dockerCliInstance != nil {
 		client = dockerCliInstance
 		return
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	client, err = createDockerCli()
 	if err != nil {
 		return nil, err

--- a/service/docker.go
+++ b/service/docker.go
@@ -18,8 +18,8 @@ func dockerCli() (client *docker.Client, err error) {
 		client = dockerCliInstance
 		return
 	}
-	mu.Lock()
-	defer mu.Unlock()
+	// mu.Lock()
+	// defer mu.Unlock()
 	client, err = createDockerCli()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The problem was coming kind of randomly so it was a good chance to be a concurrency.

The docker cli instance was created without any lock and after the initialization the swarm was created but during the time of the swarm creation another test was accessing it and the swarm was not yet created

fix #116 