### PR TITLE
Make applications more developer friendly

### DIFF
--- a/api/core/helpers.go
+++ b/api/core/helpers.go
@@ -1,0 +1,112 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/mesg-foundation/core/service"
+	"google.golang.org/grpc"
+)
+
+type workflow struct {
+	service   *service.Service
+	event     string
+	listeners []*task
+}
+
+type task struct {
+	service *service.Service
+	task    string
+	convert func(data *EventData) interface{}
+}
+
+var once sync.Once
+var workflows []*workflow
+var cli CoreClient
+
+func connect() {
+	once.Do(func() {
+		connection, _ := grpc.Dial(":50052", grpc.WithInsecure())
+		cli = NewCoreClient(connection)
+	})
+}
+
+func start(service *service.Service) {
+	cli.StartService(context.Background(), &StartServiceRequest{
+		Service: service,
+	})
+}
+
+func StartWorkflow() {
+	abort := make(chan os.Signal, 1)
+	signal.Notify(abort, syscall.SIGINT, syscall.SIGTERM)
+	<-abort
+	for _, wf := range workflows {
+		cli.StopService(context.Background(), &StopServiceRequest{Service: wf.service})
+		for _, task := range wf.listeners {
+			cli.StopService(context.Background(), &StopServiceRequest{Service: task.service})
+		}
+	}
+}
+
+func When(service *service.Service, event string) (wf *workflow) {
+	connect()
+	start(service)
+	stream, err := cli.ListenEvent(context.Background(), &ListenEventRequest{
+		Service: service,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	wf = &workflow{
+		service: service,
+	}
+	go func() {
+		for {
+			e, _ := stream.Recv()
+			if strings.Compare(e.EventKey, event) == 0 {
+				wf.executeAll(e)
+			}
+		}
+	}()
+
+	wf = &workflow{
+		service: service,
+	}
+	workflows = append(workflows, wf)
+	return
+}
+
+func (workflow *workflow) Then(service *service.Service, taskName string, convert func(data *EventData) interface{}) {
+	connect()
+	start(service)
+	workflow.listeners = append(workflow.listeners, &task{
+		service: service,
+		task:    taskName,
+		convert: convert,
+	})
+}
+
+func (workflow *workflow) executeAll(event *EventData) {
+	for _, task := range workflow.listeners {
+		in := task.convert(event)
+		d, err := json.Marshal(in)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		_, err = cli.ExecuteTask(context.Background(), &ExecuteTaskRequest{
+			Service:  task.service,
+			TaskData: string(d),
+			TaskKey:  task.task,
+		})
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+}


### PR DESCRIPTION
### DO NOT MERGE

## Proposal

This is a proposal to make application code way easier. right now there is too much boilerplate example:
https://github.com/mesg-foundation/application-devcon-update-on-slack/blob/master/main.go

We should be able to reduce it to only 
```When(service, "event").Then(service, "task", calculateInputs)```

This is one way to do that.

## Example application with those functions

The exact same application would be as follow
```go
package main

import (
	"os"

	"github.com/mesg-foundation/core/api/core"
	"github.com/mesg-foundation/core/service"
)

func main() {
	devcon, _ := service.ImportFromPath("../../services/devcon-update")
	slack, _ := service.ImportFromPath("../../services/slack")

	core.
		When(devcon, "update").
		Then(slack, "notify", func(data *core.EventData) interface{} {
			return map[string]string{
				"channel": "conferences",
				"title":   "Update on https://devcon.ethereum.org",
				"token":   os.Getenv("SLACK_TOKEN"),
			}
		})

	core.StartWorkflow()
}
```

## Notes 

This code is just a proof of concept and needs to be re-written and tested, it's actually just a test