### PR TITLE
Fix concurrency issue with the database

### DIFF
--- a/database/services/db_test.go
+++ b/database/services/db_test.go
@@ -1,7 +1,10 @@
 package services
 
 import (
+	"sync"
 	"testing"
+
+	"github.com/mesg-foundation/core/service"
 
 	"github.com/stvp/assert"
 )
@@ -11,4 +14,25 @@ func TestDb(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, db)
 	close()
+}
+
+// Test to stress the database with concurrency access
+// BUG: https://github.com/mesg-foundation/core/issues/163
+func TestConcurrency(t *testing.T) {
+	var wg sync.WaitGroup
+	service := &service.Service{
+		Name: "TestConcurrency",
+	}
+	hash, _ := Save(service)
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			s, err := Get(hash)
+			assert.Nil(t, err)
+			assert.Equal(t, s.Name, service.Name)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	Delete(hash)
 }


### PR DESCRIPTION
I added a new tests that was able to reproduce the concurrency issue and the fix associated, it was a bad use of wait groups in some cases 2 different goroutine can access it and so the second one was waiting and we had a dead lock on all the database