### PR TITLE
Fix daemon env MESG.PATH

### DIFF
--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -74,7 +74,7 @@ func serviceConfig(network *docker.Network) docker.CreateServiceOptions {
 				ContainerSpec: &swarm.ContainerSpec{
 					Image: viper.GetString(config.DaemonImage),
 					Env: []string{
-						"MESG.PATH=" + viper.GetString(config.MESGPath),
+						"MESG.PATH=/mesg",
 					},
 					Mounts: []mount.Mount{
 						mount.Mount{


### PR DESCRIPTION
In the start of daemon, the env `MESG.PATH` was set to `viper.GetString(config.MESGPath)` thus pointing to my local user directory. Changed to `/mesg`.