### PR TITLE
Add ServiceOptions to describe docker service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Changed
 - (#174) Update CI to build version based on tags
 - (#173) Use official Docker client
+- (#175) Changed the struct to use to start docker service
 
 #### Added
 - (#174) Add CHANGELOG.md file

--- a/container/service.go
+++ b/container/service.go
@@ -36,12 +36,13 @@ func FindService(namespace []string) (service swarm.Service, err error) {
 }
 
 // StartService starts a docker service
-func StartService(spec swarm.ServiceSpec) (serviceID string, err error) {
+func StartService(options ServiceOptions) (serviceID string, err error) {
 	client, err := Client()
 	if err != nil {
 		return
 	}
-	response, err := client.ServiceCreate(context.Background(), spec, types.ServiceCreateOptions{})
+	options.merge()
+	response, err := client.ServiceCreate(context.Background(), options.ServiceSpec, types.ServiceCreateOptions{})
 	if err != nil {
 		return
 	}

--- a/container/service.go
+++ b/container/service.go
@@ -41,8 +41,8 @@ func StartService(options ServiceOptions) (serviceID string, err error) {
 	if err != nil {
 		return
 	}
-	options.merge()
-	response, err := client.ServiceCreate(context.Background(), options.ServiceSpec, types.ServiceCreateOptions{})
+	service := options.toSwarmServiceSpec()
+	response, err := client.ServiceCreate(context.Background(), service, types.ServiceCreateOptions{})
 	if err != nil {
 		return
 	}

--- a/container/service_options.go
+++ b/container/service_options.go
@@ -1,0 +1,131 @@
+package container
+
+import (
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/swarm"
+)
+
+// ServiceOptions is a simplify version of swarm.ServiceSpec that can be merge to it
+type ServiceOptions struct {
+	Image       string
+	Namespace   []string
+	Ports       []Port
+	Mounts      []Mount
+	Env         []string
+	Args        []string
+	NetworksID  []string
+	Labels      map[string]string
+	ServiceSpec swarm.ServiceSpec
+}
+
+// Port is a simplify version of swarm.PortConfig
+type Port struct {
+	Target    uint32
+	Published uint32
+}
+
+// Mount is a simplify version of mount.Mount
+type Mount struct {
+	Source string
+	Target string
+}
+
+func (options *ServiceOptions) merge() {
+	options.initCreateServiceOptions()
+	options.mergeNamespace()
+	options.mergeImage()
+	options.mergeLabels()
+	options.mergePorts()
+	options.mergeMounts()
+	options.mergeEnv()
+	options.mergeArgs()
+	options.mergeNetworks()
+}
+
+func (options *ServiceOptions) initCreateServiceOptions() {
+	if options.ServiceSpec.Annotations.Labels == nil {
+		options.ServiceSpec.Annotations.Labels = make(map[string]string)
+	}
+	if options.ServiceSpec.EndpointSpec == nil {
+		options.ServiceSpec.EndpointSpec = &swarm.EndpointSpec{}
+	}
+	if options.ServiceSpec.EndpointSpec.Ports == nil {
+		options.ServiceSpec.EndpointSpec.Ports = make([]swarm.PortConfig, 0)
+	}
+	if options.ServiceSpec.TaskTemplate.ContainerSpec == nil {
+		options.ServiceSpec.TaskTemplate.ContainerSpec = &swarm.ContainerSpec{}
+	}
+	if options.ServiceSpec.TaskTemplate.Networks == nil {
+		options.ServiceSpec.TaskTemplate.Networks = make([]swarm.NetworkAttachmentConfig, 0)
+	}
+	if options.ServiceSpec.TaskTemplate.ContainerSpec.Args == nil {
+		options.ServiceSpec.TaskTemplate.ContainerSpec.Args = make([]string, 0)
+	}
+	if options.ServiceSpec.TaskTemplate.ContainerSpec.Env == nil {
+		options.ServiceSpec.TaskTemplate.ContainerSpec.Env = make([]string, 0)
+	}
+	if options.ServiceSpec.TaskTemplate.ContainerSpec.Mounts == nil {
+		options.ServiceSpec.TaskTemplate.ContainerSpec.Mounts = make([]mount.Mount, 0)
+	}
+	if options.ServiceSpec.TaskTemplate.ContainerSpec.Labels == nil {
+		options.ServiceSpec.TaskTemplate.ContainerSpec.Labels = make(map[string]string)
+	}
+}
+
+func (options *ServiceOptions) mergeNamespace() {
+	namespace := Namespace(options.Namespace)
+	options.ServiceSpec.Annotations.Name = namespace
+	options.ServiceSpec.Annotations.Labels["com.docker.stack.namespace"] = namespace
+	options.ServiceSpec.TaskTemplate.ContainerSpec.Labels["com.docker.stack.namespace"] = namespace
+}
+
+func (options *ServiceOptions) mergeImage() {
+	options.ServiceSpec.Annotations.Labels["com.docker.stack.image"] = options.Image
+	options.ServiceSpec.TaskTemplate.ContainerSpec.Image = options.Image
+}
+
+func (options *ServiceOptions) mergeLabels() {
+	for k, v := range options.Labels {
+		options.ServiceSpec.Annotations.Labels[k] = v
+	}
+}
+
+func (options *ServiceOptions) mergePorts() {
+	ports := make([]swarm.PortConfig, len(options.Ports))
+	for i, p := range options.Ports {
+		ports[i] = swarm.PortConfig{
+			Protocol:      swarm.PortConfigProtocolTCP,
+			PublishMode:   swarm.PortConfigPublishModeIngress,
+			TargetPort:    p.Target,
+			PublishedPort: p.Published,
+		}
+	}
+	options.ServiceSpec.EndpointSpec.Ports = append(options.ServiceSpec.EndpointSpec.Ports, ports...)
+}
+
+func (options *ServiceOptions) mergeMounts() {
+	mounts := make([]mount.Mount, len(options.Mounts))
+	for i, m := range options.Mounts {
+		mounts[i] = mount.Mount{
+			Source: m.Source,
+			Target: m.Target,
+		}
+	}
+	options.ServiceSpec.TaskTemplate.ContainerSpec.Mounts = append(options.ServiceSpec.TaskTemplate.ContainerSpec.Mounts, mounts...)
+}
+
+func (options *ServiceOptions) mergeEnv() {
+	options.ServiceSpec.TaskTemplate.ContainerSpec.Env = append(options.ServiceSpec.TaskTemplate.ContainerSpec.Env, options.Env...)
+}
+
+func (options *ServiceOptions) mergeArgs() {
+	options.ServiceSpec.TaskTemplate.ContainerSpec.Args = append(options.ServiceSpec.TaskTemplate.ContainerSpec.Args, options.Args...)
+}
+
+func (options *ServiceOptions) mergeNetworks() {
+	for _, networkID := range options.NetworksID {
+		options.ServiceSpec.TaskTemplate.Networks = append(options.ServiceSpec.TaskTemplate.Networks, swarm.NetworkAttachmentConfig{
+			Target: networkID,
+		})
+	}
+}

--- a/container/service_options_test.go
+++ b/container/service_options_test.go
@@ -3,8 +3,6 @@ package container
 import (
 	"testing"
 
-	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/stvp/assert"
 )
 
@@ -14,10 +12,10 @@ func TestServiceOptionMergeNamespace(t *testing.T) {
 		Namespace: namespace,
 	}
 	expectedNamespace := Namespace(namespace)
-	options.merge()
-	assert.Equal(t, expectedNamespace, options.ServiceSpec.Annotations.Name)
-	assert.Equal(t, expectedNamespace, options.ServiceSpec.Annotations.Labels["com.docker.stack.namespace"])
-	assert.Equal(t, expectedNamespace, options.ServiceSpec.TaskTemplate.ContainerSpec.Labels["com.docker.stack.namespace"])
+	service := options.toSwarmServiceSpec()
+	assert.Equal(t, expectedNamespace, service.Annotations.Name)
+	assert.Equal(t, expectedNamespace, service.Annotations.Labels["com.docker.stack.namespace"])
+	assert.Equal(t, expectedNamespace, service.TaskTemplate.ContainerSpec.Labels["com.docker.stack.namespace"])
 }
 
 func TestServiceOptionMergeImage(t *testing.T) {
@@ -25,9 +23,9 @@ func TestServiceOptionMergeImage(t *testing.T) {
 	options := &ServiceOptions{
 		Image: image,
 	}
-	options.merge()
-	assert.Equal(t, image, options.ServiceSpec.Annotations.Labels["com.docker.stack.image"])
-	assert.Equal(t, image, options.ServiceSpec.TaskTemplate.ContainerSpec.Image)
+	service := options.toSwarmServiceSpec()
+	assert.Equal(t, image, service.Annotations.Labels["com.docker.stack.image"])
+	assert.Equal(t, image, service.TaskTemplate.ContainerSpec.Image)
 }
 
 func TestServiceOptionMergeLabels(t *testing.T) {
@@ -37,30 +35,9 @@ func TestServiceOptionMergeLabels(t *testing.T) {
 			"label2": "bar",
 		},
 	}
-	options.merge()
-	assert.Equal(t, "foo", options.ServiceSpec.Annotations.Labels["label1"])
-	assert.Equal(t, "bar", options.ServiceSpec.Annotations.Labels["label2"])
-}
-
-func TestServiceOptionMergeLabelsWithExisting(t *testing.T) {
-	options := &ServiceOptions{
-		Labels: map[string]string{
-			"label1": "foo",
-			"label2": "bar",
-		},
-		ServiceSpec: swarm.ServiceSpec{
-			Annotations: swarm.Annotations{
-				Labels: map[string]string{
-					"label1": "should be replaced",
-					"label3": "bar",
-				},
-			},
-		},
-	}
-	options.merge()
-	assert.Equal(t, "foo", options.ServiceSpec.Annotations.Labels["label1"])
-	assert.Equal(t, "bar", options.ServiceSpec.Annotations.Labels["label2"])
-	assert.Equal(t, "bar", options.ServiceSpec.Annotations.Labels["label3"])
+	service := options.toSwarmServiceSpec()
+	assert.Equal(t, "foo", service.Annotations.Labels["label1"])
+	assert.Equal(t, "bar", service.Annotations.Labels["label2"])
 }
 
 func TestServiceOptionMergePorts(t *testing.T) {
@@ -76,58 +53,13 @@ func TestServiceOptionMergePorts(t *testing.T) {
 			},
 		},
 	}
-	options.merge()
-	ports := options.ServiceSpec.EndpointSpec.Ports
+	service := options.toSwarmServiceSpec()
+	ports := service.EndpointSpec.Ports
 	assert.Equal(t, 2, len(ports))
 	assert.Equal(t, uint32(50503), ports[0].PublishedPort)
 	assert.Equal(t, uint32(50501), ports[0].TargetPort)
 	assert.Equal(t, uint32(30503), ports[1].PublishedPort)
 	assert.Equal(t, uint32(30501), ports[1].TargetPort)
-}
-
-func TestServiceOptionMergePortsWithExisting(t *testing.T) {
-	options := &ServiceOptions{
-		Ports: []Port{
-			Port{
-				Published: 50503,
-				Target:    50501,
-			},
-			Port{
-				Published: 30503,
-				Target:    30501,
-			},
-		},
-		ServiceSpec: swarm.ServiceSpec{
-			EndpointSpec: &swarm.EndpointSpec{
-				Ports: []swarm.PortConfig{
-					swarm.PortConfig{
-						Protocol:      swarm.PortConfigProtocolTCP,
-						PublishMode:   swarm.PortConfigPublishModeIngress,
-						PublishedPort: uint32(231),
-						TargetPort:    uint32(232),
-					},
-					swarm.PortConfig{
-						Protocol:      swarm.PortConfigProtocolTCP,
-						PublishMode:   swarm.PortConfigPublishModeIngress,
-						PublishedPort: uint32(131),
-						TargetPort:    uint32(132),
-					},
-				},
-			},
-		},
-	}
-	options.merge()
-
-	ports := options.ServiceSpec.EndpointSpec.Ports
-	assert.Equal(t, 4, len(ports))
-	assert.Equal(t, uint32(231), ports[0].PublishedPort)
-	assert.Equal(t, uint32(232), ports[0].TargetPort)
-	assert.Equal(t, uint32(131), ports[1].PublishedPort)
-	assert.Equal(t, uint32(132), ports[1].TargetPort)
-	assert.Equal(t, uint32(50503), ports[2].PublishedPort)
-	assert.Equal(t, uint32(50501), ports[2].TargetPort)
-	assert.Equal(t, uint32(30503), ports[3].PublishedPort)
-	assert.Equal(t, uint32(30501), ports[3].TargetPort)
 }
 
 func TestServiceOptionMergeMounts(t *testing.T) {
@@ -139,110 +71,31 @@ func TestServiceOptionMergeMounts(t *testing.T) {
 			},
 		},
 	}
-	options.merge()
-	mounts := options.ServiceSpec.TaskTemplate.ContainerSpec.Mounts
+	service := options.toSwarmServiceSpec()
+	mounts := service.TaskTemplate.ContainerSpec.Mounts
 	assert.Equal(t, 1, len(mounts))
 	assert.Equal(t, "source/file", mounts[0].Source)
 	assert.Equal(t, "target/file", mounts[0].Target)
-}
-
-func TestServiceOptionMergeMountsWithExisting(t *testing.T) {
-	options := &ServiceOptions{
-		Mounts: []Mount{
-			Mount{
-				Source: "source/file2",
-				Target: "target/file2",
-			},
-		},
-		ServiceSpec: swarm.ServiceSpec{
-			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: &swarm.ContainerSpec{
-					Mounts: []mount.Mount{
-						mount.Mount{
-							Source: "source/file1",
-							Target: "target/file1",
-						},
-					},
-				},
-			},
-		},
-	}
-	options.merge()
-	mounts := options.ServiceSpec.TaskTemplate.ContainerSpec.Mounts
-	assert.Equal(t, 2, len(mounts))
-	assert.Equal(t, "source/file1", mounts[0].Source)
-	assert.Equal(t, "target/file1", mounts[0].Target)
-	assert.Equal(t, "source/file2", mounts[1].Source)
-	assert.Equal(t, "target/file2", mounts[1].Target)
 }
 
 func TestServiceOptionMergeEnv(t *testing.T) {
 	options := &ServiceOptions{
 		Env: []string{"env1", "env2"},
 	}
-	options.merge()
-
-	env := options.ServiceSpec.TaskTemplate.ContainerSpec.Env
+	service := options.toSwarmServiceSpec()
+	env := service.TaskTemplate.ContainerSpec.Env
 	assert.Equal(t, 2, len(env))
 	assert.Equal(t, "env1", env[0])
 	assert.Equal(t, "env2", env[1])
-}
-
-func TestServiceOptionMergeEnvWithExisting(t *testing.T) {
-	options := &ServiceOptions{
-		Env: []string{"env1", "env2"},
-		ServiceSpec: swarm.ServiceSpec{
-			TaskTemplate: swarm.TaskSpec{
-				ContainerSpec: &swarm.ContainerSpec{
-					Env: []string{"env3", "env4"},
-				},
-			},
-		},
-	}
-	options.merge()
-
-	env := options.ServiceSpec.TaskTemplate.ContainerSpec.Env
-	assert.Equal(t, 4, len(env))
-	assert.Equal(t, "env3", env[0])
-	assert.Equal(t, "env4", env[1])
-	assert.Equal(t, "env1", env[2])
-	assert.Equal(t, "env2", env[3])
 }
 
 func TestServiceOptionMergeNetworks(t *testing.T) {
 	options := &ServiceOptions{
 		NetworksID: []string{"network1", "network2"},
 	}
-	options.merge()
-
-	networks := options.ServiceSpec.TaskTemplate.Networks
+	service := options.toSwarmServiceSpec()
+	networks := service.TaskTemplate.Networks
 	assert.Equal(t, 2, len(networks))
 	assert.Equal(t, "network1", networks[0].Target)
 	assert.Equal(t, "network2", networks[1].Target)
-}
-
-func TestServiceOptionMergeNetworksWithExisting(t *testing.T) {
-	options := &ServiceOptions{
-		NetworksID: []string{"network1", "network2"},
-		ServiceSpec: swarm.ServiceSpec{
-			TaskTemplate: swarm.TaskSpec{
-				Networks: []swarm.NetworkAttachmentConfig{
-					swarm.NetworkAttachmentConfig{
-						Target: "network3",
-					},
-					swarm.NetworkAttachmentConfig{
-						Target: "network4",
-					},
-				},
-			},
-		},
-	}
-	options.merge()
-
-	networks := options.ServiceSpec.TaskTemplate.Networks
-	assert.Equal(t, 4, len(networks))
-	assert.Equal(t, "network3", networks[0].Target)
-	assert.Equal(t, "network4", networks[1].Target)
-	assert.Equal(t, "network1", networks[2].Target)
-	assert.Equal(t, "network2", networks[3].Target)
 }

--- a/container/service_options_test.go
+++ b/container/service_options_test.go
@@ -1,0 +1,248 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stvp/assert"
+)
+
+func TestServiceOptionMergeNamespace(t *testing.T) {
+	namespace := []string{"name1", "name2"}
+	options := &ServiceOptions{
+		Namespace: namespace,
+	}
+	expectedNamespace := Namespace(namespace)
+	options.merge()
+	assert.Equal(t, expectedNamespace, options.ServiceSpec.Annotations.Name)
+	assert.Equal(t, expectedNamespace, options.ServiceSpec.Annotations.Labels["com.docker.stack.namespace"])
+	assert.Equal(t, expectedNamespace, options.ServiceSpec.TaskTemplate.ContainerSpec.Labels["com.docker.stack.namespace"])
+}
+
+func TestServiceOptionMergeImage(t *testing.T) {
+	image := "nginx"
+	options := &ServiceOptions{
+		Image: image,
+	}
+	options.merge()
+	assert.Equal(t, image, options.ServiceSpec.Annotations.Labels["com.docker.stack.image"])
+	assert.Equal(t, image, options.ServiceSpec.TaskTemplate.ContainerSpec.Image)
+}
+
+func TestServiceOptionMergeLabels(t *testing.T) {
+	options := &ServiceOptions{
+		Labels: map[string]string{
+			"label1": "foo",
+			"label2": "bar",
+		},
+	}
+	options.merge()
+	assert.Equal(t, "foo", options.ServiceSpec.Annotations.Labels["label1"])
+	assert.Equal(t, "bar", options.ServiceSpec.Annotations.Labels["label2"])
+}
+
+func TestServiceOptionMergeLabelsWithExisting(t *testing.T) {
+	options := &ServiceOptions{
+		Labels: map[string]string{
+			"label1": "foo",
+			"label2": "bar",
+		},
+		ServiceSpec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{
+				Labels: map[string]string{
+					"label1": "should be replaced",
+					"label3": "bar",
+				},
+			},
+		},
+	}
+	options.merge()
+	assert.Equal(t, "foo", options.ServiceSpec.Annotations.Labels["label1"])
+	assert.Equal(t, "bar", options.ServiceSpec.Annotations.Labels["label2"])
+	assert.Equal(t, "bar", options.ServiceSpec.Annotations.Labels["label3"])
+}
+
+func TestServiceOptionMergePorts(t *testing.T) {
+	options := &ServiceOptions{
+		Ports: []Port{
+			Port{
+				Published: 50503,
+				Target:    50501,
+			},
+			Port{
+				Published: 30503,
+				Target:    30501,
+			},
+		},
+	}
+	options.merge()
+	ports := options.ServiceSpec.EndpointSpec.Ports
+	assert.Equal(t, 2, len(ports))
+	assert.Equal(t, uint32(50503), ports[0].PublishedPort)
+	assert.Equal(t, uint32(50501), ports[0].TargetPort)
+	assert.Equal(t, uint32(30503), ports[1].PublishedPort)
+	assert.Equal(t, uint32(30501), ports[1].TargetPort)
+}
+
+func TestServiceOptionMergePortsWithExisting(t *testing.T) {
+	options := &ServiceOptions{
+		Ports: []Port{
+			Port{
+				Published: 50503,
+				Target:    50501,
+			},
+			Port{
+				Published: 30503,
+				Target:    30501,
+			},
+		},
+		ServiceSpec: swarm.ServiceSpec{
+			EndpointSpec: &swarm.EndpointSpec{
+				Ports: []swarm.PortConfig{
+					swarm.PortConfig{
+						Protocol:      swarm.PortConfigProtocolTCP,
+						PublishMode:   swarm.PortConfigPublishModeIngress,
+						PublishedPort: uint32(231),
+						TargetPort:    uint32(232),
+					},
+					swarm.PortConfig{
+						Protocol:      swarm.PortConfigProtocolTCP,
+						PublishMode:   swarm.PortConfigPublishModeIngress,
+						PublishedPort: uint32(131),
+						TargetPort:    uint32(132),
+					},
+				},
+			},
+		},
+	}
+	options.merge()
+
+	ports := options.ServiceSpec.EndpointSpec.Ports
+	assert.Equal(t, 4, len(ports))
+	assert.Equal(t, uint32(231), ports[0].PublishedPort)
+	assert.Equal(t, uint32(232), ports[0].TargetPort)
+	assert.Equal(t, uint32(131), ports[1].PublishedPort)
+	assert.Equal(t, uint32(132), ports[1].TargetPort)
+	assert.Equal(t, uint32(50503), ports[2].PublishedPort)
+	assert.Equal(t, uint32(50501), ports[2].TargetPort)
+	assert.Equal(t, uint32(30503), ports[3].PublishedPort)
+	assert.Equal(t, uint32(30501), ports[3].TargetPort)
+}
+
+func TestServiceOptionMergeMounts(t *testing.T) {
+	options := &ServiceOptions{
+		Mounts: []Mount{
+			Mount{
+				Source: "source/file",
+				Target: "target/file",
+			},
+		},
+	}
+	options.merge()
+	mounts := options.ServiceSpec.TaskTemplate.ContainerSpec.Mounts
+	assert.Equal(t, 1, len(mounts))
+	assert.Equal(t, "source/file", mounts[0].Source)
+	assert.Equal(t, "target/file", mounts[0].Target)
+}
+
+func TestServiceOptionMergeMountsWithExisting(t *testing.T) {
+	options := &ServiceOptions{
+		Mounts: []Mount{
+			Mount{
+				Source: "source/file2",
+				Target: "target/file2",
+			},
+		},
+		ServiceSpec: swarm.ServiceSpec{
+			TaskTemplate: swarm.TaskSpec{
+				ContainerSpec: &swarm.ContainerSpec{
+					Mounts: []mount.Mount{
+						mount.Mount{
+							Source: "source/file1",
+							Target: "target/file1",
+						},
+					},
+				},
+			},
+		},
+	}
+	options.merge()
+	mounts := options.ServiceSpec.TaskTemplate.ContainerSpec.Mounts
+	assert.Equal(t, 2, len(mounts))
+	assert.Equal(t, "source/file1", mounts[0].Source)
+	assert.Equal(t, "target/file1", mounts[0].Target)
+	assert.Equal(t, "source/file2", mounts[1].Source)
+	assert.Equal(t, "target/file2", mounts[1].Target)
+}
+
+func TestServiceOptionMergeEnv(t *testing.T) {
+	options := &ServiceOptions{
+		Env: []string{"env1", "env2"},
+	}
+	options.merge()
+
+	env := options.ServiceSpec.TaskTemplate.ContainerSpec.Env
+	assert.Equal(t, 2, len(env))
+	assert.Equal(t, "env1", env[0])
+	assert.Equal(t, "env2", env[1])
+}
+
+func TestServiceOptionMergeEnvWithExisting(t *testing.T) {
+	options := &ServiceOptions{
+		Env: []string{"env1", "env2"},
+		ServiceSpec: swarm.ServiceSpec{
+			TaskTemplate: swarm.TaskSpec{
+				ContainerSpec: &swarm.ContainerSpec{
+					Env: []string{"env3", "env4"},
+				},
+			},
+		},
+	}
+	options.merge()
+
+	env := options.ServiceSpec.TaskTemplate.ContainerSpec.Env
+	assert.Equal(t, 4, len(env))
+	assert.Equal(t, "env3", env[0])
+	assert.Equal(t, "env4", env[1])
+	assert.Equal(t, "env1", env[2])
+	assert.Equal(t, "env2", env[3])
+}
+
+func TestServiceOptionMergeNetworks(t *testing.T) {
+	options := &ServiceOptions{
+		NetworksID: []string{"network1", "network2"},
+	}
+	options.merge()
+
+	networks := options.ServiceSpec.TaskTemplate.Networks
+	assert.Equal(t, 2, len(networks))
+	assert.Equal(t, "network1", networks[0].Target)
+	assert.Equal(t, "network2", networks[1].Target)
+}
+
+func TestServiceOptionMergeNetworksWithExisting(t *testing.T) {
+	options := &ServiceOptions{
+		NetworksID: []string{"network1", "network2"},
+		ServiceSpec: swarm.ServiceSpec{
+			TaskTemplate: swarm.TaskSpec{
+				Networks: []swarm.NetworkAttachmentConfig{
+					swarm.NetworkAttachmentConfig{
+						Target: "network3",
+					},
+					swarm.NetworkAttachmentConfig{
+						Target: "network4",
+					},
+				},
+			},
+		},
+	}
+	options.merge()
+
+	networks := options.ServiceSpec.TaskTemplate.Networks
+	assert.Equal(t, 4, len(networks))
+	assert.Equal(t, "network3", networks[0].Target)
+	assert.Equal(t, "network4", networks[1].Target)
+	assert.Equal(t, "network1", networks[2].Target)
+	assert.Equal(t, "network2", networks[3].Target)
+}

--- a/container/service_test.go
+++ b/container/service_test.go
@@ -3,27 +3,13 @@ package container
 import (
 	"testing"
 
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/stvp/assert"
 )
 
 func startTestService(name []string) (serviceID string, err error) {
-	namespace := Namespace(name)
-	return StartService(swarm.ServiceSpec{
-		Annotations: swarm.Annotations{
-			Name: namespace,
-			Labels: map[string]string{
-				"com.docker.stack.namespace": namespace,
-			},
-		},
-		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: &swarm.ContainerSpec{
-				Image: "nginx",
-				Labels: map[string]string{
-					"com.docker.stack.namespace": namespace,
-				},
-			},
-		},
+	return StartService(ServiceOptions{
+		Image:     "nginx",
+		Namespace: name,
 	})
 }
 
@@ -135,40 +121,18 @@ func TestFindServiceStopped(t *testing.T) {
 }
 
 func TestListServices(t *testing.T) {
-	namespace := Namespace([]string{"TestListServices"})
-	namespace2 := Namespace([]string{"TestListServiceswithValue2"})
-	StartService(swarm.ServiceSpec{
-		Annotations: swarm.Annotations{
-			Name: namespace,
-			Labels: map[string]string{
-				"com.docker.stack.namespace": namespace,
-				"label_name":                 "value_1",
-			},
-		},
-		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: &swarm.ContainerSpec{
-				Image: "nginx",
-				Labels: map[string]string{
-					"com.docker.stack.namespace": namespace,
-				},
-			},
+	StartService(ServiceOptions{
+		Image:     "nginx",
+		Namespace: []string{"TestListServices"},
+		Labels: map[string]string{
+			"label_name": "value_1",
 		},
 	})
-	StartService(swarm.ServiceSpec{
-		Annotations: swarm.Annotations{
-			Name: namespace2,
-			Labels: map[string]string{
-				"com.docker.stack.namespace": namespace2,
-				"label_name_2":               "value_2",
-			},
-		},
-		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: &swarm.ContainerSpec{
-				Image: "nginx",
-				Labels: map[string]string{
-					"com.docker.stack.namespace": namespace2,
-				},
-			},
+	StartService(ServiceOptions{
+		Image:     "nginx",
+		Namespace: []string{"TestListServiceswithValue2"},
+		Labels: map[string]string{
+			"label_name_2": "value_2",
 		},
 	})
 	defer StopService([]string{"TestListServices"})

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -3,8 +3,6 @@ package daemon
 import (
 	"path/filepath"
 
-	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/mesg-foundation/core/config"
 	"github.com/mesg-foundation/core/container"
 	"github.com/spf13/viper"
@@ -26,52 +24,30 @@ func Start() (serviceID string, err error) {
 	return container.StartService(serviceSpec(sharedNetworkID))
 }
 
-func serviceSpec(networkID string) swarm.ServiceSpec {
-	namespace := container.Namespace([]string{name})
-	return swarm.ServiceSpec{
-		Annotations: swarm.Annotations{
-			Name: namespace,
-			Labels: map[string]string{
-				"com.docker.stack.image":     viper.GetString(config.DaemonImage),
-				"com.docker.stack.namespace": namespace,
+func serviceSpec(networkID string) container.ServiceOptions {
+	return container.ServiceOptions{
+		Namespace: []string{name},
+		Image:     viper.GetString(config.DaemonImage),
+		Env: []string{
+			"MESG.PATH=/mesg",
+			"API.SERVICE.SOCKETPATH=" + filepath.Join(viper.GetString(config.MESGPath), "server.sock"),
+		},
+		Mounts: []container.Mount{
+			container.Mount{
+				Source: dockerSocket,
+				Target: dockerSocket,
+			},
+			container.Mount{
+				Source: viper.GetString(config.MESGPath),
+				Target: "/mesg",
 			},
 		},
-		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: &swarm.ContainerSpec{
-				Image: viper.GetString(config.DaemonImage),
-				Env: []string{
-					"MESG.PATH=/mesg",
-					"API.SERVICE.SOCKETPATH=" + filepath.Join(viper.GetString(config.MESGPath), "server.sock"),
-				},
-				Mounts: []mount.Mount{
-					mount.Mount{
-						Source: dockerSocket,
-						Target: dockerSocket,
-					},
-					mount.Mount{
-						Source: viper.GetString(config.MESGPath),
-						Target: "/mesg",
-					},
-				},
-				Labels: map[string]string{
-					"com.docker.stack.namespace": namespace,
-				},
+		Ports: []container.Port{
+			container.Port{
+				Target:    50052,
+				Published: 50052,
 			},
 		},
-		EndpointSpec: &swarm.EndpointSpec{
-			Ports: []swarm.PortConfig{
-				swarm.PortConfig{
-					Protocol:      swarm.PortConfigProtocolTCP,
-					PublishMode:   swarm.PortConfigPublishModeIngress,
-					TargetPort:    50052,
-					PublishedPort: 50052,
-				},
-			},
-		},
-		Networks: []swarm.NetworkAttachmentConfig{
-			swarm.NetworkAttachmentConfig{
-				Target: networkID,
-			},
-		},
+		NetworksID: []string{networkID},
 	}
 }

--- a/daemon/start_test.go
+++ b/daemon/start_test.go
@@ -43,17 +43,16 @@ func startForTest() {
 
 func TestStartConfig(t *testing.T) {
 	spec := serviceSpec("networkID")
-	assert.NotNil(t, spec)
 	// Make sure that the config directory is passed in parameter to write on the same folder
-	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Env[0], "MESG.PATH=/mesg")
-	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Env[1], "API.SERVICE.SOCKETPATH="+filepath.Join(viper.GetString(config.MESGPath), "server.sock"))
+	assert.Equal(t, spec.Env[0], "MESG.PATH=/mesg")
+	assert.Equal(t, spec.Env[1], "API.SERVICE.SOCKETPATH="+filepath.Join(viper.GetString(config.MESGPath), "server.sock"))
 	// Ensure that the port is shared
-	assert.Equal(t, spec.ServiceSpec.EndpointSpec.Ports[0].PublishedPort, uint32(50052))
-	assert.Equal(t, spec.ServiceSpec.EndpointSpec.Ports[0].TargetPort, uint32(50052))
+	assert.Equal(t, spec.Ports[0].Published, uint32(50052))
+	assert.Equal(t, spec.Ports[0].Target, uint32(50052))
 	// Ensure that the docker socket is shared in the daemon
-	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Mounts[0].Source, "/var/run/docker.sock")
-	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Mounts[0].Target, "/var/run/docker.sock")
+	assert.Equal(t, spec.Mounts[0].Source, "/var/run/docker.sock")
+	assert.Equal(t, spec.Mounts[0].Target, "/var/run/docker.sock")
 	// Ensure that the host users folder is sync with the daemon
-	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Mounts[1].Source, viper.GetString(config.MESGPath))
-	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Mounts[1].Target, "/mesg")
+	assert.Equal(t, spec.Mounts[1].Source, viper.GetString(config.MESGPath))
+	assert.Equal(t, spec.Mounts[1].Target, "/mesg")
 }

--- a/daemon/start_test.go
+++ b/daemon/start_test.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/mesg-foundation/core/config"
 	"github.com/mesg-foundation/core/container"
 	"github.com/spf13/viper"
@@ -24,28 +23,10 @@ func startForTest() {
 	if err != nil {
 		panic(err)
 	}
-	namespace := container.Namespace([]string{name})
-	_, err = container.StartService(swarm.ServiceSpec{
-		Annotations: swarm.Annotations{
-			Name: namespace,
-			Labels: map[string]string{
-				"com.docker.stack.image":     viper.GetString(config.DaemonImage),
-				"com.docker.stack.namespace": namespace,
-			},
-		},
-		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: &swarm.ContainerSpec{
-				Image: "nginx",
-				Labels: map[string]string{
-					"com.docker.stack.namespace": namespace,
-				},
-			},
-		},
-		Networks: []swarm.NetworkAttachmentConfig{
-			swarm.NetworkAttachmentConfig{
-				Target: sharedNetworkID,
-			},
-		},
+	_, err = container.StartService(container.ServiceOptions{
+		Namespace:  []string{name},
+		Image:      "nginx",
+		NetworksID: []string{sharedNetworkID},
 	})
 	if err != nil {
 		panic(err)

--- a/daemon/start_test.go
+++ b/daemon/start_test.go
@@ -45,15 +45,15 @@ func TestStartConfig(t *testing.T) {
 	spec := serviceSpec("networkID")
 	assert.NotNil(t, spec)
 	// Make sure that the config directory is passed in parameter to write on the same folder
-	assert.Equal(t, spec.TaskTemplate.ContainerSpec.Env[0], "MESG.PATH=/mesg")
-	assert.Equal(t, spec.TaskTemplate.ContainerSpec.Env[1], "API.SERVICE.SOCKETPATH="+filepath.Join(viper.GetString(config.MESGPath), "server.sock"))
+	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Env[0], "MESG.PATH=/mesg")
+	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Env[1], "API.SERVICE.SOCKETPATH="+filepath.Join(viper.GetString(config.MESGPath), "server.sock"))
 	// Ensure that the port is shared
-	assert.Equal(t, spec.EndpointSpec.Ports[0].PublishedPort, uint32(50052))
-	assert.Equal(t, spec.EndpointSpec.Ports[0].TargetPort, uint32(50052))
+	assert.Equal(t, spec.ServiceSpec.EndpointSpec.Ports[0].PublishedPort, uint32(50052))
+	assert.Equal(t, spec.ServiceSpec.EndpointSpec.Ports[0].TargetPort, uint32(50052))
 	// Ensure that the docker socket is shared in the daemon
-	assert.Equal(t, spec.TaskTemplate.ContainerSpec.Mounts[0].Source, "/var/run/docker.sock")
-	assert.Equal(t, spec.TaskTemplate.ContainerSpec.Mounts[0].Target, "/var/run/docker.sock")
+	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Mounts[0].Source, "/var/run/docker.sock")
+	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Mounts[0].Target, "/var/run/docker.sock")
 	// Ensure that the host users folder is sync with the daemon
-	assert.Equal(t, spec.TaskTemplate.ContainerSpec.Mounts[1].Source, viper.GetString(config.MESGPath))
-	assert.Equal(t, spec.TaskTemplate.ContainerSpec.Mounts[1].Target, "/mesg")
+	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Mounts[1].Source, viper.GetString(config.MESGPath))
+	assert.Equal(t, spec.ServiceSpec.TaskTemplate.ContainerSpec.Mounts[1].Target, "/mesg")
 }

--- a/service/dependency.go
+++ b/service/dependency.go
@@ -6,15 +6,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/mesg-foundation/core/config"
 	"github.com/mesg-foundation/core/container"
 	"github.com/spf13/viper"
 )
 
-func extractPorts(dependency *Dependency) (ports []swarm.PortConfig) {
-	ports = make([]swarm.PortConfig, len(dependency.Ports))
+func extractPorts(dependency *Dependency) (ports []container.Port) {
+	ports = make([]container.Port, len(dependency.Ports))
 	for i, p := range dependency.Ports {
 		split := strings.Split(p, ":")
 		from, _ := strconv.ParseUint(split[0], 10, 64)
@@ -22,22 +20,20 @@ func extractPorts(dependency *Dependency) (ports []swarm.PortConfig) {
 		if len(split) > 1 {
 			to, _ = strconv.ParseUint(split[1], 10, 64)
 		}
-		ports[i] = swarm.PortConfig{
-			Protocol:      swarm.PortConfigProtocolTCP,
-			PublishMode:   swarm.PortConfigPublishModeIngress,
-			TargetPort:    uint32(to),
-			PublishedPort: uint32(from),
+		ports[i] = container.Port{
+			Target:    uint32(to),
+			Published: uint32(from),
 		}
 	}
 	return
 }
 
-func extractVolumes(service *Service, dependency *Dependency, details dependencyDetails) (volumes []mount.Mount) {
-	volumes = make([]mount.Mount, 0)
+func extractVolumes(service *Service, dependency *Dependency, details dependencyDetails) (volumes []container.Mount) {
+	volumes = make([]container.Mount, 0)
 	for _, volume := range dependency.Volumes {
 		path := filepath.Join(details.namespace, details.dependencyName, volume)
 		source := filepath.Join(viper.GetString(config.ServicePathHost), path)
-		volumes = append(volumes, mount.Mount{
+		volumes = append(volumes, container.Mount{
 			Source: source,
 			Target: volume,
 		})
@@ -47,7 +43,7 @@ func extractVolumes(service *Service, dependency *Dependency, details dependency
 		for _, volume := range service.Dependencies[dep].Volumes {
 			path := filepath.Join(details.namespace, dep, volume)
 			source := filepath.Join(viper.GetString(config.ServicePathHost), path)
-			volumes = append(volumes, mount.Mount{
+			volumes = append(volumes, container.Mount{
 				Source: source,
 				Target: volume,
 			})

--- a/service/dependency_test.go
+++ b/service/dependency_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"testing"
 
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/stvp/assert"
 )
 
@@ -20,10 +19,8 @@ func TestExtractPorts(t *testing.T) {
 		},
 	})
 	assert.Equal(t, len(ports), 2)
-	assert.Equal(t, ports[0].PublishMode, swarm.PortConfigPublishModeIngress)
-	assert.Equal(t, ports[0].Protocol, swarm.PortConfigProtocolTCP)
-	assert.Equal(t, ports[0].TargetPort, uint32(80))
-	assert.Equal(t, ports[0].PublishedPort, uint32(80))
-	assert.Equal(t, ports[1].TargetPort, uint32(8080))
-	assert.Equal(t, ports[1].PublishedPort, uint32(3000))
+	assert.Equal(t, ports[0].Target, uint32(80))
+	assert.Equal(t, ports[0].Published, uint32(80))
+	assert.Equal(t, ports[1].Target, uint32(8080))
+	assert.Equal(t, ports[1].Published, uint32(3000))
 }


### PR DESCRIPTION
This PR should be merged after https://github.com/mesg-foundation/core/pull/173

This PR remove the dependencies from other package to docker by adding container.ServiceOptions.
It's only make the declaration of Docker service way easier and normalize them by adding labels in the right place.