### PR TITLE
fix issue when sharing folder between containers

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -44,6 +44,7 @@ func serviceConfig(networkID string) godocker.CreateServiceOptions {
 					Env: []string{
 						"MESG.PATH=/mesg",
 						"API.SERVICE.SOCKETPATH=" + filepath.Join(viper.GetString(config.MESGPath), "server.sock"),
+						"SERVICE.PATH.HOST=" + filepath.Join(viper.GetString(config.MESGPath), "services"),
 					},
 					Mounts: []mount.Mount{
 						mount.Mount{

--- a/daemon/start_test.go
+++ b/daemon/start_test.go
@@ -69,6 +69,7 @@ func TestStartConfig(t *testing.T) {
 	// Make sure that the config directory is passed in parameter to write on the same folder
 	assert.Equal(t, service.ServiceSpec.TaskTemplate.ContainerSpec.Env[0], "MESG.PATH=/mesg")
 	assert.Equal(t, service.ServiceSpec.TaskTemplate.ContainerSpec.Env[1], "API.SERVICE.SOCKETPATH="+filepath.Join(viper.GetString(config.MESGPath), "server.sock"))
+	assert.Equal(t, service.ServiceSpec.TaskTemplate.ContainerSpec.Env[2], "SERVICE.PATH.HOST="+filepath.Join(viper.GetString(config.MESGPath), "services"))
 	// Ensure that the port is shared
 	assert.Equal(t, service.ServiceSpec.EndpointSpec.Ports[0].PublishedPort, uint32(50052))
 	assert.Equal(t, service.ServiceSpec.EndpointSpec.Ports[0].TargetPort, uint32(50052))


### PR DESCRIPTION
It was not possible to access the volumes from docker because we were taking the path of the daemon and not the one from the host