### PR TITLE
Fix services image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - run: go get -t ./...
       - run: docker swarm init
       - run: docker pull nginx
+      - run: docker pull alpine
       - run: env CORE.IMAGE=mesg/core:$CIRCLE_SHA1 go test -timeout 180s -p 1 -coverprofile=coverage.txt ./...
       - run: bash <(curl -s https://codecov.io/bash)
 

--- a/service/start.go
+++ b/service/start.go
@@ -38,16 +38,16 @@ func (service *Service) Start() (serviceIDs []string, err error) {
 			serviceHash:    service.Hash(),
 		}
 		wg.Add(1)
-		go func(service *Service, d dependencyDetails, name string, i int) {
+		go func(service *Service, dep *Dependency, d dependencyDetails, name string, i int) {
 			defer wg.Done()
-			serviceID, errStart := dependency.Start(service, d, networkID)
+			serviceID, errStart := dep.Start(service, d, networkID)
 			mutex.Lock()
 			defer mutex.Unlock()
 			serviceIDs[i] = serviceID
 			if errStart != nil && err == nil {
 				err = errStart
 			}
-		}(service, d, name, i)
+		}(service, dependency, d, name, i)
 		i++
 	}
 	wg.Wait()

--- a/service/start_test.go
+++ b/service/start_test.go
@@ -29,16 +29,20 @@ func TestStartWith2Dependencies(t *testing.T) {
 		Name: "TestStartWith2Dependencies",
 		Dependencies: map[string]*Dependency{
 			"test": &Dependency{
-				Image: "nginx",
+				Image: "nginx:latest",
 			},
 			"test2": &Dependency{
-				Image: "nginx",
+				Image: "alpine:latest",
 			},
 		},
 	}
 	servicesID, err := service.Start()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(servicesID))
+	container1, _ := container.FindContainer([]string{"TestStartWith2Dependencies", "test"})
+	container2, _ := container.FindContainer([]string{"TestStartWith2Dependencies", "test2"})
+	assert.Equal(t, "nginx:latest", container1.Config.Image)
+	assert.Equal(t, "alpine:latest", container2.Config.Image)
 	service.Stop()
 }
 


### PR DESCRIPTION
When starting a service with multiple dependencies, all docker containers were started with the same image tag...
This PR fix it.