### PR TITLE
Add version number to the cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run: go get ./...
       - run: go get github.com/karalabe/xgo
       - run: mkdir bin
-      - run: cd bin; xgo --targets=darwin/386,darwin/amd64,linux/386,linux/amd64,windows/386,windows/amd64 -out mesg-core ../cli
+      - run: cd bin; xgo --targets=darwin/386,darwin/amd64,linux/386,linux/amd64,windows/386,windows/amd64 -ldflags='-X main.version=$CIRCLE_TAG' -out mesg-core ../cli
       - run: sudo chmod +x ./bin/*
       - run: go get -u github.com/tcnksm/ghr
       - run: ghr -u mesg-foundation -r core -delete $CIRCLE_TAG ./bin

--- a/cli/main.go
+++ b/cli/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 // version of this release. Will be replaced automatically when compiling in CI
-var version = "v1.0.0-beta"
+var version = "vX.X.X"
 
 func init() {
 	cmd.RootCmd.Version = version

--- a/cli/main.go
+++ b/cli/main.go
@@ -6,6 +6,14 @@ import (
 	"github.com/mesg-foundation/core/cmd"
 )
 
+// version of this release. Will be replaced automatically when compiling in CI
+var version = "v1.0.0-beta"
+
+func init() {
+	cmd.RootCmd.Version = version
+	cmd.RootCmd.Short = cmd.RootCmd.Short + " " + version
+}
+
 func main() {
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
The CLI now has a version number.
It can be set manually in `cli/main.go` `version` variable.
Or it is set automatically during the compilation of the release of the CLI by setting the `ldflags`.
Source: https://stackoverflow.com/questions/11354518/golang-application-auto-build-versioning

Close https://github.com/mesg-foundation/core/issues/210