### PR TITLE
Add service logs command

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -25,6 +25,7 @@ func init() {
 	Service.AddCommand(cmdService.Status)
 	Service.AddCommand(cmdService.Init)
 	Service.AddCommand(cmdService.Delete)
+	Service.AddCommand(cmdService.Logs)
 
 	RootCmd.AddCommand(Service)
 }

--- a/cmd/service/logs.go
+++ b/cmd/service/logs.go
@@ -1,0 +1,47 @@
+package cmdService
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mesg-foundation/core/cmd/utils"
+
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/logrusorgru/aurora"
+	serviceDB "github.com/mesg-foundation/core/database/services"
+	"github.com/spf13/cobra"
+)
+
+// Logs of the core
+var Logs = &cobra.Command{
+	Use:   "logs",
+	Short: "Show the logs of a service",
+	Example: `mesg-core service logs SERVICE_ID
+	mesg-core service logs SERVICE_ID --dependency DEPENDENCY_NAME`,
+	Run:               logsHandler,
+	Args:              cobra.MinimumNArgs(1),
+	DisableAutoGenTag: true,
+}
+
+func init() {
+	Logs.Flags().StringP("dependency", "d", "*", "Name of the dependency to only show the logs from")
+}
+
+func logsHandler(cmd *cobra.Command, args []string) {
+	serviceID := args[0]
+	service, err := serviceDB.Get(serviceID)
+	if err != nil {
+		return
+	}
+	dependency := cmd.Flag("dependency").Value.String()
+	readers, err := service.Logs(dependency)
+	if err != nil {
+		fmt.Println(aurora.Red(err))
+		return
+	}
+	for _, reader := range readers {
+		defer reader.Close()
+		go stdcopy.StdCopy(os.Stdout, os.Stderr, reader)
+	}
+	<-cmdUtils.WaitForCancel()
+}

--- a/cmd/service/logs.go
+++ b/cmd/service/logs.go
@@ -17,7 +17,7 @@ var Logs = &cobra.Command{
 	Use:   "logs",
 	Short: "Show the logs of a service",
 	Example: `mesg-core service logs SERVICE_ID
-	mesg-core service logs SERVICE_ID --dependency DEPENDENCY_NAME`,
+mesg-core service logs SERVICE_ID --dependency DEPENDENCY_NAME`,
 	Run:               logsHandler,
 	Args:              cobra.MinimumNArgs(1),
 	DisableAutoGenTag: true,

--- a/service/logs.go
+++ b/service/logs.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"io"
+
+	"github.com/mesg-foundation/core/container"
+)
+
+// Logs return the service's docker service logs. Optionally only show the logs of a given dependency
+func (service *Service) Logs(onlyForDependency string) (readers []io.ReadCloser, err error) {
+	for depName := range service.GetDependencies() {
+		if onlyForDependency == "" || onlyForDependency == "*" || onlyForDependency == depName {
+			namespace := []string{service.namespace(), depName} //TODO: refacto namespace
+			var reader io.ReadCloser
+			reader, err = container.ServiceLogs(namespace)
+			if err != nil {
+				break
+			}
+			readers = append(readers, reader)
+		}
+	}
+	return
+}

--- a/service/logs_test.go
+++ b/service/logs_test.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stvp/assert"
+)
+
+func TestLogs(t *testing.T) {
+	service := &Service{
+		Name: "TestLogs",
+		Dependencies: map[string]*Dependency{
+			"test": &Dependency{
+				Image: "nginx",
+			},
+			"test2": &Dependency{
+				Image: "nginx",
+			},
+		},
+	}
+	service.Start()
+	readers, err := service.Logs("*")
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(readers))
+	defer service.Stop()
+}
+
+func TestLogsOnlyOneDependency(t *testing.T) {
+	service := &Service{
+		Name: "TestLogsOnlyOneDependency",
+		Dependencies: map[string]*Dependency{
+			"test": &Dependency{
+				Image: "nginx",
+			},
+			"test2": &Dependency{
+				Image: "nginx",
+			},
+		},
+	}
+	service.Start()
+	readers, err := service.Logs("test2")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(readers))
+	defer service.Stop()
+}

--- a/service/status.go
+++ b/service/status.go
@@ -60,6 +60,7 @@ func (dependency *Dependency) IsStopped(namespace string, name string) (running 
 	return
 }
 
+//TODO: should move to its own file
 // ListRunning all the running services
 func ListRunning() (res []string, err error) {
 	services, err := container.ListServices("mesg.hash")

--- a/service/status.go
+++ b/service/status.go
@@ -60,8 +60,8 @@ func (dependency *Dependency) IsStopped(namespace string, name string) (running 
 	return
 }
 
-//TODO: should move to its own file
 // ListRunning all the running services
+// TODO: should move to its own file
 func ListRunning() (res []string, err error) {
 	services, err := container.ListServices("mesg.hash")
 	mapRes := make(map[string]uint)


### PR DESCRIPTION
Dependent on https://github.com/mesg-foundation/core/pull/221
Start https://github.com/mesg-foundation/core/issues/215

Add command service logs, that can display all the docker logs of a service or only a specific dependency.
```
mesg-core service logs SERVICE_ID
mesg-core service logs SERVICE_ID --dependency DEPENDENCY_NAME
```

We should improve the output with prefix of dependency name and colors, but for now I think it's enough.