### PR TITLE
Template for the service init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Changed
 - (#247) Update the `service init` command to have initial tasks and events
-- (#257) Update the `service init` command to fetch for template based on the https://github.com/mesg-foundation/awesome/blob/master/templates.json file
+- (#257) Update the `service init` command to fetch for template based on the https://github.com/mesg-foundation/awesome/blob/master/templates.json file but also custom templates by giving the address of the template
 
 #### Added
 - (#246) Add .mesgignore to excluding file from the Docker build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Changed
 - (#247) Update the `service init` command to have initial tasks and events
-- (#) Update the `service init` command to fetch for template based on the https://github.com/mesg-foundation/awesome/blob/master/templates.json file
+- (#257) Update the `service init` command to fetch for template based on the https://github.com/mesg-foundation/awesome/blob/master/templates.json file
 
 #### Added
 - (#246) Add .mesgignore to excluding file from the Docker build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Changed
 - (#247) Update the `service init` command to have initial tasks and events
+- (#) Update the `service init` command to fetch for template based on the https://github.com/mesg-foundation/awesome/blob/master/templates.json file
 
 #### Added
 - (#246) Add .mesgignore to excluding file from the Docker build

--- a/cmd/service/init.go
+++ b/cmd/service/init.go
@@ -1,42 +1,28 @@
 package service
 
 import (
-	"bytes"
+	"encoding/json"
 	"fmt"
-	"html/template"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/AlecAivazis/survey.v1"
+
 	"github.com/logrusorgru/aurora"
 	"github.com/mesg-foundation/core/cmd/utils"
-	"github.com/mesg-foundation/core/service"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1"
 )
 
-const templateText = `name: "{{.Name}}"
-description: "{{.Description}}"
-tasks:
-  foo:
-    name: "Foo"
-    inputs:
-      inputA:
-        type: String
-      inputB:
-        type: Number
-    outputs:
-      outputX:
-        data:
-          resultX:
-            type: String
-events:
-  eventX:
-    data:
-      dataA:
-        type: String
-`
+const templatesURL = "https://raw.githubusercontent.com/mesg-foundation/awesome/master/templates.json"
+const addMyOwn = "Add my own"
+
+type template struct {
+	Name string
+	URL  string
+}
 
 // Init run the Init command for a service
 var Init = &cobra.Command{
@@ -52,41 +38,103 @@ mesg-core service init --current`,
 	DisableAutoGenTag: true,
 }
 
+func init() {
+	Init.Flags().StringP("name", "n", "", "Name")
+	Init.Flags().StringP("description", "d", "", "Description")
+	Init.Flags().BoolP("current", "c", false, "Create the service in the current path")
+	Init.Flags().StringP("template", "t", "", "Specify a template to download for your application")
+}
+
 func initHandler(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", aurora.Bold("Initialization of a new service"))
 
-	res := buildService(cmd)
-
-	mesgFile, err := generateMesgFile(&res)
+	tmpl := &template{
+		URL:  cmd.Flag("template").Value.String(),
+		Name: cmd.Flag("template").Value.String(),
+	}
+	if tmpl.URL == "" {
+		templates, err := getTemplates(templatesURL)
+		utils.HandleError(err)
+		tmpl, err = selectTemplate(templates)
+		utils.HandleError(err)
+		if tmpl == nil {
+			os.Exit(0)
+		}
+	}
+	path, err := downloadTemplate(tmpl)
 	utils.HandleError(err)
-
-	ok := false
-	fmt.Println()
-	fmt.Println(string(mesgFile))
-	if survey.AskOne(&survey.Confirm{Message: "Is this correct?", Default: true}, &ok, nil) != nil {
-		os.Exit(0)
-	}
-	if !ok {
-		return
-	}
-
-	folder := strings.Replace(strings.ToLower(res.Name), " ", "-", -1)
+	defer os.RemoveAll(path)
+	replacements := askReplacements(cmd)
+	folder := strings.Replace(strings.ToLower(replacements["name"]), " ", "-", -1)
 	if cmd.Flag("current").Value.String() == "true" {
 		folder = "./"
 	}
-	err = writeInFolder(folder, mesgFile)
+	err = copyDir(path+"/template", folder, replacements)
 	utils.HandleError(err)
-	fmt.Printf("%s\n", aurora.Green("Service created with success in folder '"+folder+"'").Bold())
+	fmt.Println(aurora.Green("Service created in folder: " + folder))
 }
 
-func generateMesgFile(service *service.Service) (res []byte, err error) {
-	var doc bytes.Buffer
-	tmpl, err := template.New("service-init").Parse(templateText)
+func getTemplates(url string) (templates []*template, err error) {
+	client := http.Client{}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return
 	}
-	err = tmpl.Execute(&doc, service)
-	res = doc.Bytes()
+	res, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(body, &templates)
+	return
+}
+
+func selectTemplate(templates []*template) (tmpl *template, err error) {
+	var result string
+	if survey.AskOne(&survey.Select{
+		Message: "Select your template",
+		Options: templatesToOption(templates),
+	}, &result, nil) != nil {
+		os.Exit(0)
+	}
+	tmpl = getTemplateResult(result, templates)
+	return
+}
+
+func templatesToOption(templates []*template) (options []string) {
+	options = []string{}
+	for _, template := range templates {
+		options = append(options, template.Name+" ("+template.URL+")")
+	}
+	options = append(options, addMyOwn)
+	return
+}
+
+func getTemplateResult(result string, templates []*template) (tmpl *template) {
+	if result == addMyOwn {
+		fmt.Println(aurora.Green("Go to https://github.com/mesg-foundation/awesome/blob/master/templates.json"))
+		return
+	}
+	for _, template := range templates {
+		if template.Name+" ("+template.URL+")" == result {
+			tmpl = template
+			break
+		}
+	}
+	return
+}
+
+func downloadTemplate(tmpl *template) (path string, err error) {
+	path, err = createTempFolder()
+	if err != nil {
+		return
+	}
+	err = gitClone(tmpl.URL, path, "Download template "+tmpl.Name+"...")
 	return
 }
 
@@ -100,32 +148,79 @@ func ask(label string, value string, validator survey.Validator) string {
 	return value
 }
 
-func buildService(cmd *cobra.Command) (res service.Service) {
-	res.Name = ask("Name:", cmd.Flag("name").Value.String(), survey.Required)
-	res.Description = ask("Description:", cmd.Flag("description").Value.String(), nil)
+func askReplacements(cmd *cobra.Command) (replacement map[string]string) {
+	replacement = make(map[string]string)
+	replacement["name"] = ask("Name:", cmd.Flag("name").Value.String(), survey.Required)
+	replacement["description"] = ask("Description:", cmd.Flag("description").Value.String(), nil)
 	return
 }
 
-func writeInFolder(folder string, content []byte) (err error) {
-	if folder != "./" {
-		err = os.Mkdir(folder, os.ModePerm)
-		if err != nil {
-			return
+func copyDir(src string, dst string, replacement map[string]string) (err error) {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+	err = os.MkdirAll(dst, os.ModePerm)
+	if err != nil {
+		return
+	}
+
+	entries, err := ioutil.ReadDir(src)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			err = copyDir(srcPath, dstPath, replacement)
+			if err != nil {
+				break
+			}
+		} else {
+			// Skip symlinks.
+			if entry.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+
+			err = copyFile(srcPath, dstPath, replacement)
+			if err != nil {
+				break
+			}
 		}
 	}
-	err = ioutil.WriteFile(filepath.Join(folder, "mesg.yml"), content, os.ModePerm)
+
+	return
+
+}
+
+func copyFile(src, dst string, replacement map[string]string) (err error) {
+	in, err := os.Open(src)
 	if err != nil {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(folder, "Dockerfile"), []byte(""), os.ModePerm)
+	defer in.Close()
+
+	out, err := os.Create(dst)
 	if err != nil {
 		return
 	}
+	defer out.Close()
+
+	err = transform(dst, src, replacement)
 	return
 }
 
-func init() {
-	Init.Flags().StringP("name", "n", "", "Name")
-	Init.Flags().StringP("description", "d", "", "Description")
-	Init.Flags().BoolP("current", "c", false, "Create the service in the current path")
+func transform(dest string, source string, replacement map[string]string) (err error) {
+	body, err := ioutil.ReadFile(source)
+	if err != nil {
+		return
+	}
+	res := string(body)
+	for key, value := range replacement {
+		res = strings.Replace(res, "{{"+key+"}}", value, -1)
+	}
+	si, err := os.Stat(source)
+	ioutil.WriteFile(dest, []byte(res), si.Mode())
+	return
 }

--- a/cmd/service/init_test.go
+++ b/cmd/service/init_test.go
@@ -1,42 +1,56 @@
 package service
 
 import (
-	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/mesg-foundation/core/service"
 	"github.com/stvp/assert"
 )
 
-func TestWriteInFolder(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "TestWriteInFolder")
-	os.RemoveAll(dir)
-	err := writeInFolder(dir, []byte("hello world"))
-	defer os.RemoveAll(dir)
+func TestGetTemplate(t *testing.T) {
+	templates, err := getTemplates(templatesURL)
 	assert.Nil(t, err)
-	mesg, err := ioutil.ReadFile(filepath.Join(dir, "mesg.yml"))
-	assert.Nil(t, err)
-	assert.Equal(t, string(mesg), "hello world")
-	_, err = ioutil.ReadFile(filepath.Join(dir, "Dockerfile"))
-	assert.Nil(t, err)
+	assert.True(t, len(templates) > 0)
 }
 
-func TestWriteInFolderExistingFolder(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "TestWriteInFolder")
-	err := writeInFolder(dir, []byte("hello world"))
-	defer os.RemoveAll(dir)
+func TestGetTemplateBadURL(t *testing.T) {
+	_, err := getTemplates("...")
 	assert.NotNil(t, err)
 }
 
-func TestGenerateMesgFile(t *testing.T) {
-	file, err := generateMesgFile(&service.Service{
-		Name:        "TestGenerateMesgFile",
-		Description: "description",
-	})
+func TestTemplatesToOption(t *testing.T) {
+	templates := []*template{
+		&template{Name: "xxx", URL: "https://..."},
+		&template{Name: "yyy", URL: "https://..."},
+	}
+	options := templatesToOption(templates)
+	assert.Equal(t, len(options), len(templates)+1)
+	assert.Equal(t, options[0], "xxx (https://...)")
+	assert.Equal(t, options[1], "yyy (https://...)")
+	assert.Equal(t, options[2], addMyOwn)
+}
+
+func TestGetTemplateResultAddMyOwn(t *testing.T) {
+	assert.Nil(t, getTemplateResult(addMyOwn, []*template{}))
+}
+
+func TestGetTemplateResultAdd(t *testing.T) {
+	templates := []*template{
+		&template{Name: "xxx", URL: "https://..."},
+		&template{Name: "yyy", URL: "https://..."},
+	}
+	result := "yyy (https://...)"
+	tmpl := getTemplateResult(result, templates)
+	assert.NotNil(t, tmpl)
+	assert.Equal(t, tmpl.Name, templates[1].Name)
+}
+
+func TestDownloadTemplate(t *testing.T) {
+	tmpl := &template{
+		URL: "https://github.com/mesg-foundation/template-service-javascript",
+	}
+	path, err := downloadTemplate(tmpl)
+	defer os.RemoveAll(path)
 	assert.Nil(t, err)
-	res := strings.Replace(strings.Replace(templateText, "{{.Name}}", "TestGenerateMesgFile", -1), "{{.Description}}", "description", -1)
-	assert.Equal(t, string(file), res)
+	assert.NotNil(t, path)
 }

--- a/cmd/service/init_test.go
+++ b/cmd/service/init_test.go
@@ -24,10 +24,11 @@ func TestTemplatesToOption(t *testing.T) {
 		&template{Name: "yyy", URL: "https://..."},
 	}
 	options := templatesToOption(templates)
-	assert.Equal(t, len(options), len(templates)+1)
+	assert.Equal(t, len(options), len(templates)+2)
 	assert.Equal(t, options[0], "xxx (https://...)")
 	assert.Equal(t, options[1], "yyy (https://...)")
-	assert.Equal(t, options[2], addMyOwn)
+	assert.Equal(t, options[2], custom)
+	assert.Equal(t, options[3], addMyOwn)
 }
 
 func TestGetTemplateResultAddMyOwn(t *testing.T) {

--- a/cmd/service/utils.go
+++ b/cmd/service/utils.go
@@ -32,10 +32,10 @@ func prepareService(path string) (importedService *service.Service) {
 	path, didDownload, err := downloadServiceIfNeeded(path)
 	utils.HandleError(err)
 	if didDownload {
+		defer os.RemoveAll(path)
 		fmt.Println(aurora.Green("Service downloaded with success"))
 		fmt.Println("Temp folder: " + path)
 	}
-	defer removeTempFolder(path, didDownload)
 	importedService, err = service.ImportFromPath(path)
 	if err != nil {
 		fmt.Println("Run the command 'service validate' to get detailed errors")
@@ -57,14 +57,14 @@ func downloadServiceIfNeeded(path string) (newPath string, didDownload bool, err
 		if err != nil {
 			return
 		}
-		err = gitClone(path, newPath)
+		err = gitClone(path, newPath, "Downloading service...")
 		didDownload = true
 	}
 	return
 }
 
-func gitClone(url string, path string) (err error) {
-	utils.ShowSpinnerForFunc(utils.SpinnerOptions{Text: "Downloading service..."}, func() {
+func gitClone(url string, path string, message string) (err error) {
+	utils.ShowSpinnerForFunc(utils.SpinnerOptions{Text: message}, func() {
 		_, err = git.PlainClone(path, false, &git.CloneOptions{
 			URL: url,
 		})
@@ -74,13 +74,6 @@ func gitClone(url string, path string) (err error) {
 
 func createTempFolder() (path string, err error) {
 	path, err = ioutil.TempDir("", "mesg-")
-	return
-}
-
-func removeTempFolder(path string, didDownload bool) (err error) {
-	if didDownload {
-		err = os.RemoveAll(path)
-	}
 	return
 }
 

--- a/cmd/service/utils_test.go
+++ b/cmd/service/utils_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"os"
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
@@ -20,8 +21,8 @@ func TestBuildDockerImagePathDoNotExist(t *testing.T) {
 
 func TestGitCloneRepositoryDoNotExist(t *testing.T) {
 	path, _ := createTempFolder()
-	defer removeTempFolder(path, true)
-	err := gitClone("/doNotExist", path)
+	defer os.RemoveAll(path)
+	err := gitClone("/doNotExist", path, "testing...")
 	assert.NotNil(t, err)
 }
 
@@ -44,7 +45,7 @@ func TestDownloadServiceIfNeededRelativePath(t *testing.T) {
 func TestDownloadServiceIfNeededUrl(t *testing.T) {
 	path := "https://github.com/mesg-foundation/awesome.git"
 	newPath, didDownload, err := downloadServiceIfNeeded(path)
-	defer removeTempFolder(newPath, true)
+	defer os.RemoveAll(newPath)
 	assert.Nil(t, err)
 	assert.NotEqual(t, path, newPath)
 	assert.Equal(t, true, didDownload)
@@ -52,14 +53,14 @@ func TestDownloadServiceIfNeededUrl(t *testing.T) {
 
 func TestCreateTempFolder(t *testing.T) {
 	path, err := createTempFolder()
-	defer removeTempFolder(path, true)
+	defer os.RemoveAll(path)
 	assert.Nil(t, err)
 	assert.NotEqual(t, "", path)
 }
 
 func TestRemoveTempFolder(t *testing.T) {
 	path, _ := createTempFolder()
-	err := removeTempFolder(path, true)
+	err := os.RemoveAll(path)
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
Now the `service init` command is fetching for the list of template available in the https://github.com/mesg-foundation/awesome project and once selected will fetch the template and use it as new service folder and replace what's need to be replaced

fix #245