### PR TITLE
fixed windows compatibility

### DIFF
--- a/api/core/execute.go
+++ b/api/core/execute.go
@@ -2,10 +2,9 @@ package core
 
 import (
 	"encoding/json"
+	"context"
 
 	"github.com/mesg-foundation/core/database/services"
-
-	"context"
 	"github.com/mesg-foundation/core/execution"
 )
 
@@ -20,13 +19,13 @@ func (s *Server) ExecuteTask(ctx context.Context, request *ExecuteTaskRequest) (
 	if err != nil {
 		return
 	}
-	execution, err := execution.Create(&service, request.TaskKey, inputs)
+	exec, err := execution.Create(&service, request.TaskKey, inputs)
 	if err != nil {
 		return
 	}
-	err = execution.Execute()
+	err = exec.Execute()
 	reply = &ExecuteTaskReply{
-		ExecutionID: execution.ID,
+		ExecutionID: exec.ID,
 	}
 	return
 }

--- a/api/core/execute.go
+++ b/api/core/execute.go
@@ -1,8 +1,8 @@
 package core
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 
 	"github.com/mesg-foundation/core/database/services"
 	"github.com/mesg-foundation/core/execution"

--- a/api/core/list_services.go
+++ b/api/core/list_services.go
@@ -2,17 +2,18 @@ package core
 
 import (
 	"context"
+
 	"github.com/mesg-foundation/core/database/services"
 )
 
 // ListServices return all services from the database
 func (s *Server) ListServices(ctx context.Context, request *ListServicesRequest) (reply *ListServicesReply, err error) {
-	services, err := services.All()
+	svcs, err := services.All()
 	if err != nil {
 		return
 	}
 	reply = &ListServicesReply{
-		Services: services,
+		Services: svcs,
 	}
 	return
 }

--- a/api/core/listen_event.go
+++ b/api/core/listen_event.go
@@ -14,20 +14,20 @@ import (
 
 // ListenEvent for listen event from a specific service services
 func (s *Server) ListenEvent(request *ListenEventRequest, stream Core_ListenEventServer) (err error) {
-	service, err := services.Get(request.ServiceID)
+	svc, err := services.Get(request.ServiceID)
 	if err != nil {
 		return
 	}
-	if err = validateEventKey(&service, request.EventFilter); err != nil {
+	if err = validateEventKey(&svc, request.EventFilter); err != nil {
 		return
 	}
-	subscription := pubsub.Subscribe(service.EventSubscriptionChannel())
+	subscription := pubsub.Subscribe(svc.EventSubscriptionChannel())
 	for data := range subscription {
-		event := data.(*event.Event)
-		if isSubscribedEvent(request, event) {
-			eventData, _ := json.Marshal(event.Data)
+		evt := data.(*event.Event)
+		if isSubscribedEvent(request, evt) {
+			eventData, _ := json.Marshal(evt.Data)
 			stream.Send(&EventData{
-				EventKey:  event.Key,
+				EventKey:  evt.Key,
 				EventData: string(eventData),
 			})
 		}

--- a/api/core/listen_result.go
+++ b/api/core/listen_result.go
@@ -14,25 +14,25 @@ import (
 
 // ListenResult will listen for results from a services
 func (s *Server) ListenResult(request *ListenResultRequest, stream Core_ListenResultServer) (err error) {
-	service, err := services.Get(request.ServiceID)
+	svc, err := services.Get(request.ServiceID)
 	if err != nil {
 		return
 	}
-	if err = validateTaskKey(&service, request.TaskFilter); err != nil {
+	if err = validateTaskKey(&svc, request.TaskFilter); err != nil {
 		return
 	}
-	if err = validateOutputKey(&service, request.TaskFilter, request.OutputFilter); err != nil {
+	if err = validateOutputKey(&svc, request.TaskFilter, request.OutputFilter); err != nil {
 		return
 	}
-	subscription := pubsub.Subscribe(service.ResultSubscriptionChannel())
+	subscription := pubsub.Subscribe(svc.ResultSubscriptionChannel())
 	for data := range subscription {
-		execution := data.(*execution.Execution)
-		if isSubscribedTask(request, execution) && isSubscribedOutput(request, execution) {
-			outputs, _ := json.Marshal(execution.OutputData)
+		exec := data.(*execution.Execution)
+		if isSubscribedTask(request, exec) && isSubscribedOutput(request, exec) {
+			outputs, _ := json.Marshal(exec.OutputData)
 			stream.Send(&ResultData{
-				ExecutionID: execution.ID,
-				TaskKey:     execution.Task,
-				OutputKey:   execution.Output,
+				ExecutionID: exec.ID,
+				TaskKey:     exec.Task,
+				OutputKey:   exec.Output,
 				OutputData:  string(outputs),
 			})
 		}

--- a/api/service/emit_event.go
+++ b/api/service/emit_event.go
@@ -19,11 +19,11 @@ func (s *Server) EmitEvent(context context.Context, request *EmitEventRequest) (
 	if err != nil {
 		return
 	}
-	event, err := event.Create(&service, request.EventKey, data)
+	evt, err := event.Create(&service, request.EventKey, data)
 	if err != nil {
 		return
 	}
-	event.Publish()
+	evt.Publish()
 	reply = &EmitEventReply{}
 	return
 }

--- a/api/service/listen_task.go
+++ b/api/service/listen_task.go
@@ -16,11 +16,11 @@ func (s *Server) ListenTask(request *ListenTaskRequest, stream Service_ListenTas
 	}
 	subscription := pubsub.Subscribe(service.TaskSubscriptionChannel())
 	for data := range subscription {
-		execution := data.(*execution.Execution)
-		inputs, _ := json.Marshal(execution.Inputs)
+		exec := data.(*execution.Execution)
+		inputs, _ := json.Marshal(exec.Inputs)
 		stream.Send(&TaskData{
-			ExecutionID: execution.ID,
-			TaskKey:     execution.Task,
+			ExecutionID: exec.ID,
+			TaskKey:     exec.Task,
 			InputData:   string(inputs),
 		})
 	}

--- a/api/service/submit_result.go
+++ b/api/service/submit_result.go
@@ -10,8 +10,8 @@ import (
 
 // SubmitResult of an execution
 func (s *Server) SubmitResult(context context.Context, request *SubmitResultRequest) (reply *SubmitResultReply, err error) {
-	execution := execution.InProgress(request.ExecutionID)
-	if execution == nil {
+	exec := execution.InProgress(request.ExecutionID)
+	if exec == nil {
 		err = errors.New("No task in progress with the ID " + request.ExecutionID)
 		return
 	}
@@ -20,7 +20,7 @@ func (s *Server) SubmitResult(context context.Context, request *SubmitResultRequ
 	if err != nil {
 		return
 	}
-	err = execution.Complete(request.OutputKey, data)
+	err = exec.Complete(request.OutputKey, data)
 	if err != nil {
 		return
 	}

--- a/cmd/service/assets/readmeTemplate.go
+++ b/cmd/service/assets/readmeTemplate.go
@@ -76,13 +76,13 @@ func cmdServiceAssetsReadmetemplateMdBytes() ([]byte, error) {
 }
 
 func cmdServiceAssetsReadmetemplateMd() (*asset, error) {
-	bytes, err := cmdServiceAssetsReadmetemplateMdBytes()
+	readmeBytes, err := cmdServiceAssetsReadmetemplateMdBytes()
 	if err != nil {
 		return nil, err
 	}
 
 	info := bindataFileInfo{name: "cmd/service/assets/readmeTemplate.md", size: 1140, mode: os.FileMode(420), modTime: time.Unix(1531285359, 0)}
-	a := &asset{bytes: bytes, info: info}
+	a := &asset{bytes: readmeBytes, info: info}
 	return a, nil
 }
 
@@ -181,10 +181,10 @@ type bintree struct {
 	Children map[string]*bintree
 }
 var _bintree = &bintree{nil, map[string]*bintree{
-	"cmd": &bintree{nil, map[string]*bintree{
-		"service": &bintree{nil, map[string]*bintree{
-			"assets": &bintree{nil, map[string]*bintree{
-				"readmeTemplate.md": &bintree{cmdServiceAssetsReadmetemplateMd, map[string]*bintree{}},
+	"cmd": {nil, map[string]*bintree{
+		"service": {nil, map[string]*bintree{
+			"assets": {nil, map[string]*bintree{
+				"readmeTemplate.md": {cmdServiceAssetsReadmetemplateMd, map[string]*bintree{}},
 			}},
 		}},
 	}},

--- a/cmd/service/start.go
+++ b/cmd/service/start.go
@@ -10,9 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stake float64
-var duration int
-
 // Start run the start command for a service
 var Start = &cobra.Command{
 	Use:               "start SERVICE_ID",

--- a/cmd/service/utils.go
+++ b/cmd/service/utils.go
@@ -105,15 +105,15 @@ func buildDockerImage(path string) (imageHash string, err error) {
 }
 
 func injectConfigurationInDependencies(s *service.Service, imageHash string) {
-	config := s.Configuration
-	if config == nil {
-		config = &service.Dependency{}
+	conf := s.Configuration
+	if conf == nil {
+		conf = &service.Dependency{}
 	}
 	dependency := &service.Dependency{
-		Command:     config.Command,
-		Ports:       config.Ports,
-		Volumes:     config.Volumes,
-		Volumesfrom: config.Volumesfrom,
+		Command:     conf.Command,
+		Ports:       conf.Ports,
+		Volumes:     conf.Volumes,
+		Volumesfrom: conf.Volumesfrom,
 		Image:       imageHash,
 	}
 	if s.Dependencies == nil {

--- a/config/api.go
+++ b/config/api.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/spf13/viper"
@@ -11,13 +10,13 @@ import (
 // All the configuration keys
 const (
 	APIServerAddress       = "Api.Server.Address"
-	APIServerSocket        = "Api.Server.Socket"
+	//APIServerSocket        = "Api.Server.Socket"
 	APIClientTarget        = "Api.Client.Target"
-	APIServiceTargetPath   = "Api.Service.TargetPath"
-	APIServiceTargetSocket = "Api.Service.TargetSocket"
-	APIServiceSocketPath   = "Api.Service.SocketPath"
+	//APIServiceTargetPath   = "Api.Service.TargetPath"
+	//APIServiceTargetSocket = "Api.Service.TargetSocket"
+	//APIServiceSocketPath   = "Api.Service.SocketPath"
 	ServicePathHost        = "Service.Path.Host"
-	ServicePathDocker      = "Service.Path.Docker"
+	//ServicePathDocker      = "Service.Path.Docker"
 	MESGPath               = "MESG.Path"
 	CoreImage              = "Core.Image"
 )
@@ -38,18 +37,20 @@ func init() {
 	viper.SetDefault(MESGPath, configDir)
 
 	viper.SetDefault(APIServerAddress, ":50052")
-	viper.SetDefault(APIServerSocket, "/mesg/server.sock")
-	os.MkdirAll("/mesg", os.ModePerm)
+
+	/*viper.SetDefault(APIServerSocket, "/mesg/server.sock")
+	os.MkdirAll("/mesg", os.ModePerm)*/
 
 	viper.SetDefault(APIClientTarget, viper.GetString(APIServerAddress))
 
-	viper.SetDefault(APIServiceSocketPath, filepath.Join(viper.GetString(MESGPath), "server.sock"))
+	/*viper.SetDefault(APIServiceSocketPath, filepath.Join(viper.GetString(MESGPath), "server.sock"))
 	viper.SetDefault(APIServiceTargetPath, "/mesg/server.sock")
-	viper.SetDefault(APIServiceTargetSocket, "unix://"+viper.GetString(APIServiceTargetPath))
+	viper.SetDefault(APIServiceTargetSocket, "unix://"+viper.GetString(APIServiceTargetPath))*/
 
 	viper.SetDefault(ServicePathHost, filepath.Join(viper.GetString(MESGPath), "services"))
-	viper.SetDefault(ServicePathDocker, filepath.Join("/mesg", "services"))
-	os.MkdirAll(viper.GetString(ServicePathDocker), os.ModePerm)
+
+	/*viper.SetDefault(ServicePathDocker, filepath.Join("/mesg", "services"))
+	os.MkdirAll(viper.GetString(ServicePathDocker), os.ModePerm)*/
 
 	viper.SetDefault(CoreImage, "mesg/core:latest")
 }

--- a/config/api.go
+++ b/config/api.go
@@ -9,16 +9,16 @@ import (
 
 // All the configuration keys
 const (
-	APIServerAddress       = "Api.Server.Address"
+	APIServerAddress = "Api.Server.Address"
 	//APIServerSocket        = "Api.Server.Socket"
-	APIClientTarget        = "Api.Client.Target"
+	APIClientTarget = "Api.Client.Target"
 	//APIServiceTargetPath   = "Api.Service.TargetPath"
 	//APIServiceTargetSocket = "Api.Service.TargetSocket"
 	//APIServiceSocketPath   = "Api.Service.SocketPath"
-	ServicePathHost        = "Service.Path.Host"
+	ServicePathHost = "Service.Path.Host"
 	//ServicePathDocker      = "Service.Path.Docker"
-	MESGPath               = "MESG.Path"
-	CoreImage              = "Core.Image"
+	MESGPath  = "MESG.Path"
+	CoreImage = "Core.Image"
 )
 
 func init() {

--- a/config/directory.go
+++ b/config/directory.go
@@ -13,19 +13,19 @@ var ConfigDirectory string
 var AccountDirectory string
 
 func detectHomePath() (path string, err error) {
-	user, err := user.Current()
+	u, err := user.Current()
 	if err != nil {
 		return
 	}
-	path = user.HomeDir
+	path = u.HomeDir
 	return
 }
 
 func getHomeDirectory() (directory string, err error) {
-	directory = os.Getenv("HOME")
+	/*directory = os.Getenv("HOME")
 	if directory != "" {
 		return
-	}
+	}*/
 	directory, err = detectHomePath()
 	return
 }

--- a/core/main.go
+++ b/core/main.go
@@ -17,10 +17,10 @@ func main() {
 		Network: "tcp",
 		Address: viper.GetString(config.APIServerAddress),
 	})
-	go startServer(&api.Server{
+	/*go startServer(&api.Server{
 		Network: "unix",
 		Address: viper.GetString(config.APIServerSocket),
-	})
+	})*/
 	abort := make(chan os.Signal, 1)
 	signal.Notify(abort, syscall.SIGINT, syscall.SIGTERM)
 	<-abort

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"runtime"
 	"path/filepath"
 
 	"github.com/mesg-foundation/core/config"
@@ -27,31 +28,46 @@ func serviceSpec() (spec container.ServiceOptions, err error) {
 	if err != nil {
 		return
 	}
+
+	//windows hack - TODO: Put into utility package
+	mesgHomePath := viper.GetString(config.MESGPath)
+	if runtime.GOOS == "windows" {
+		mesgHomePath = "/c" + filepath.ToSlash(mesgHomePath[2:])
+	}
+
 	spec = container.ServiceOptions{
 		Namespace: Namespace(),
 		Image:     viper.GetString(config.CoreImage),
 		Env: []string{
 			"MESG.PATH=/mesg",
-			"API.SERVICE.SOCKETPATH=" + filepath.Join(viper.GetString(config.MESGPath), "server.sock"),
-			"SERVICE.PATH.HOST=" + filepath.Join(viper.GetString(config.MESGPath), "services"),
+			//"API.SERVICE.SOCKETPATH=" + filepath.Join(viper.GetString(config.MESGPath), "server.sock"),
+			//"SERVICE.PATH.HOST=" + filepath.Join(viper.GetString(config.MESGPath), "services"),
 		},
 		Mounts: []container.Mount{
-			container.Mount{
-				Source: dockerSocket,
+			{
+				Source: getDockerSocket(),
 				Target: dockerSocket,
 			},
-			container.Mount{
-				Source: viper.GetString(config.MESGPath),
+			{
+				Source: mesgHomePath,
 				Target: "/mesg",
 			},
 		},
 		Ports: []container.Port{
-			container.Port{
+			{
 				Target:    50052,
 				Published: 50052,
 			},
 		},
 		NetworksID: []string{sharedNetworkID},
+	}
+	return
+}
+
+func getDockerSocket() (dc string) {
+	dc = dockerSocket
+	if runtime.GOOS == "windows" {
+		dc = "/" + dockerSocket
 	}
 	return
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -1,8 +1,8 @@
 package daemon
 
 import (
-	"runtime"
 	"path/filepath"
+	"runtime"
 
 	"github.com/mesg-foundation/core/config"
 	"github.com/mesg-foundation/core/container"

--- a/database/services/all.go
+++ b/database/services/all.go
@@ -14,12 +14,12 @@ func All() (services []*service.Service, err error) {
 	}
 	iter := db.NewIterator(nil, nil)
 	for iter.Next() {
-		var service service.Service
-		err = proto.Unmarshal(iter.Value(), &service)
+		var svc service.Service
+		err = proto.Unmarshal(iter.Value(), &svc)
 		if err != nil {
 			return
 		}
-		services = append(services, &service)
+		services = append(services, &svc)
 	}
 	iter.Release()
 	err = iter.Error()

--- a/service/start.go
+++ b/service/start.go
@@ -2,8 +2,8 @@ package service
 
 import (
 	"errors"
-	"runtime"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"


### PR DESCRIPTION
this PR will address issue #273 

it is still a little rough around the edges, but i think good enough to start a little discussion on the changes made.

i have quite aggressively removed anything that is using unix pipes, except for docker.sock that needs to stay in place so the container can access the host's docker daemon. windows does actually also have something like unix pipes, called npipes, but they are not compatible. i also believe that since we have plan, at least that is what i understood, to have mesg-core run on a different machine or even go server-less, going all TCP seemed the right approach here,  

i also removed mounts, env variables and directories that seemed redundant and/or not used, even in sample services/apps, including fixing variable <-> package name clashes, as well as redundant variable declarations.

i have tested everything with a small service and all seems to be working well.

please feel free to comment

![image](https://user-images.githubusercontent.com/3125440/43049079-095e630a-8e1c-11e8-9c92-b67ffd24de72.png)

![image](https://user-images.githubusercontent.com/3125440/43049089-28a22fd0-8e1c-11e8-8b7d-c0c417ea6ab6.png)
