### PR TITLE
Change testing pkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Changed
 - (#282) Branch support added. You can now specify your branches with a `#branch` fragment at the end of your git url. E.g.: https://github.com/mesg-foundation/service-ethereum-erc20#websocket
 - (#299) Add more user friendly errors when failing to connect to the Core or Docker
+- (#356) Use github.com/stretchr/testify package
 
 #### Added
 - (#242) Add more details in command `mesg-core service validate`

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -3,18 +3,18 @@ package client
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPI(t *testing.T) {
 	api, err := API()
-	assert.Nil(t, err)
-	assert.NotNil(t, api)
+	require.Nil(t, err)
+	require.NotNil(t, api)
 }
 
 func TestGetClient(t *testing.T) {
 	c, err := getClient()
-	assert.Nil(t, err)
-	assert.NotNil(t, c)
-	assert.NotNil(t, _client)
+	require.Nil(t, err)
+	require.NotNil(t, c)
+	require.NotNil(t, _client)
 }

--- a/api/client/service_test.go
+++ b/api/client/service_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServices(t *testing.T) {
@@ -14,10 +14,10 @@ func TestServices(t *testing.T) {
 		Execute:  &Task{ServiceID: "zzz"},
 	}
 	services := wf.services()
-	assert.Equal(t, len(services), 3)
-	assert.Equal(t, services[0], "xxx")
-	assert.Equal(t, services[1], "yyy")
-	assert.Equal(t, services[2], "zzz")
+	require.Equal(t, len(services), 3)
+	require.Equal(t, services[0], "xxx")
+	require.Equal(t, services[1], "yyy")
+	require.Equal(t, services[2], "zzz")
 }
 
 func TestServicesDuplicate(t *testing.T) {
@@ -27,9 +27,9 @@ func TestServicesDuplicate(t *testing.T) {
 		Execute:  &Task{ServiceID: "xxx"},
 	}
 	services := wf.services()
-	assert.Equal(t, len(services), 2)
-	assert.Equal(t, services[0], "xxx")
-	assert.Equal(t, services[1], "yyy")
+	require.Equal(t, len(services), 2)
+	require.Equal(t, services[0], "xxx")
+	require.Equal(t, services[1], "yyy")
 }
 
 func TestIterateService(t *testing.T) {
@@ -43,8 +43,8 @@ func TestIterateService(t *testing.T) {
 		cpt++
 		return nil
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, cpt, 3)
+	require.Nil(t, err)
+	require.Equal(t, cpt, 3)
 }
 
 func TestIterateServiceWithError(t *testing.T) {
@@ -56,5 +56,5 @@ func TestIterateServiceWithError(t *testing.T) {
 	err := iterateService(wf, func(ID string) error {
 		return errors.New("test error")
 	})
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }

--- a/api/client/task_test.go
+++ b/api/client/task_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/api/core"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProcessEventWithInvalidEventData(t *testing.T) {
@@ -19,7 +19,7 @@ func TestProcessEventWithInvalidEventData(t *testing.T) {
 		EventData: "",
 	}
 	err := wf.Execute.processEvent(wf, data)
-	assert.Equal(t, err.Error(), "unexpected end of JSON input")
+	require.Equal(t, err.Error(), "unexpected end of JSON input")
 }
 
 func TestProcessResulsWithInvalidEventData(t *testing.T) {
@@ -36,7 +36,7 @@ func TestProcessResulsWithInvalidEventData(t *testing.T) {
 		TaskKey:     "taskx",
 	}
 	err := wf.Execute.processResult(wf, data)
-	assert.Equal(t, err.Error(), "unexpected end of JSON input")
+	require.Equal(t, err.Error(), "unexpected end of JSON input")
 }
 
 func TestConvertData(t *testing.T) {
@@ -46,8 +46,8 @@ func TestConvertData(t *testing.T) {
 		},
 	}
 	res, err := task.convertData("foo")
-	assert.Nil(t, err)
-	assert.Equal(t, res, "\"bar\"")
+	require.Nil(t, err)
+	require.Equal(t, res, "\"bar\"")
 }
 
 func TestConvertDataObject(t *testing.T) {
@@ -60,8 +60,8 @@ func TestConvertDataObject(t *testing.T) {
 		"foo":    "bar",
 		"number": 42,
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, res, "{\"foo\":\"bar\",\"number\":42}")
+	require.Nil(t, err)
+	require.Equal(t, res, "{\"foo\":\"bar\",\"number\":42}")
 }
 
 func TestConvertDataWithNull(t *testing.T) {
@@ -71,6 +71,6 @@ func TestConvertDataWithNull(t *testing.T) {
 		},
 	}
 	res, err := task.convertData("xxx")
-	assert.Nil(t, err)
-	assert.Equal(t, res, "null")
+	require.Nil(t, err)
+	require.Equal(t, res, "null")
 }

--- a/api/client/workflow_test.go
+++ b/api/client/workflow_test.go
@@ -4,79 +4,79 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/api/core"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidEventFromAny(t *testing.T) {
 	wf := &Workflow{
 		OnEvent: &Event{Name: "*"},
 	}
-	assert.True(t, wf.validEvent(&core.EventData{EventKey: "xxx"}))
+	require.True(t, wf.validEvent(&core.EventData{EventKey: "xxx"}))
 }
 
 func TestValidEventFromValue(t *testing.T) {
 	wf := &Workflow{
 		OnEvent: &Event{Name: "xxx"},
 	}
-	assert.True(t, wf.validEvent(&core.EventData{EventKey: "xxx"}))
-	assert.False(t, wf.validEvent(&core.EventData{EventKey: "yyy"}))
+	require.True(t, wf.validEvent(&core.EventData{EventKey: "xxx"}))
+	require.False(t, wf.validEvent(&core.EventData{EventKey: "yyy"}))
 }
 
 func TestValidResultFromAnyNameAndAnyOutput(t *testing.T) {
 	wf := &Workflow{
 		OnResult: &Result{Name: "*", Output: "*"},
 	}
-	assert.True(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "xxx"}))
+	require.True(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "xxx"}))
 }
 
 func TestValidResultFromAnyNameAndNotAnyOutput(t *testing.T) {
 	wf := &Workflow{
 		OnResult: &Result{Name: "*", Output: "xxx"},
 	}
-	assert.True(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "xxx"}))
-	assert.False(t, wf.validResult(&core.ResultData{TaskKey: "yyy", OutputKey: "yyy"}))
+	require.True(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "xxx"}))
+	require.False(t, wf.validResult(&core.ResultData{TaskKey: "yyy", OutputKey: "yyy"}))
 }
 
 func TestValidResultFromNotAnyNameAndAnyOutput(t *testing.T) {
 	wf := &Workflow{
 		OnResult: &Result{Name: "xxx", Output: "*"},
 	}
-	assert.True(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "xxx"}))
-	assert.False(t, wf.validResult(&core.ResultData{TaskKey: "yyy", OutputKey: "yyy"}))
+	require.True(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "xxx"}))
+	require.False(t, wf.validResult(&core.ResultData{TaskKey: "yyy", OutputKey: "yyy"}))
 }
 
 func TestValidResultFromNotAnyNameAndNotAnyOutput(t *testing.T) {
 	wf := &Workflow{
 		OnResult: &Result{Name: "xxx", Output: "yyy"},
 	}
-	assert.True(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "yyy"}))
-	assert.False(t, wf.validResult(&core.ResultData{TaskKey: "yyy", OutputKey: "yyy"}))
-	assert.False(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "xxx"}))
-	assert.False(t, wf.validResult(&core.ResultData{TaskKey: "yyy", OutputKey: "xxx"}))
+	require.True(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "yyy"}))
+	require.False(t, wf.validResult(&core.ResultData{TaskKey: "yyy", OutputKey: "yyy"}))
+	require.False(t, wf.validResult(&core.ResultData{TaskKey: "xxx", OutputKey: "xxx"}))
+	require.False(t, wf.validResult(&core.ResultData{TaskKey: "yyy", OutputKey: "xxx"}))
 }
 
 func TestInvalidListenResult(t *testing.T) {
 	wf := &Workflow{
 		OnResult: &Result{},
 	}
-	assert.NotNil(t, listenResults(wf))
+	require.NotNil(t, listenResults(wf))
 }
 
 func TestInvalidListenEvent(t *testing.T) {
 	wf := &Workflow{
 		OnEvent: &Event{},
 	}
-	assert.NotNil(t, listenEvents(wf))
+	require.NotNil(t, listenEvents(wf))
 }
 
 func TestInvalidWorkflowWithNoExecute(t *testing.T) {
 	wf := Workflow{OnEvent: &Event{}}
 	err := wf.Start()
-	assert.Equal(t, err.Error(), "A workflow needs a task")
+	require.Equal(t, err.Error(), "A workflow needs a task")
 }
 
 func TestInvalidWorkflowWithNoEvent(t *testing.T) {
 	wf := Workflow{Execute: &Task{}}
 	err := wf.Start()
-	assert.Equal(t, err.Error(), "A workflow needs an event OnEvent or OnResult")
+	require.Equal(t, err.Error(), "A workflow needs an event OnEvent or OnResult")
 }

--- a/api/core/delete_test.go
+++ b/api/core/delete_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mesg-foundation/core/database/services"
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var serverdelete = new(Server)
@@ -27,8 +27,8 @@ func TestDeleteService(t *testing.T) {
 	reply, err := serverdelete.DeleteService(context.Background(), &DeleteServiceRequest{
 		ServiceID: deployment.ServiceID,
 	})
-	assert.Nil(t, err)
-	assert.NotNil(t, reply)
+	require.Nil(t, err)
+	require.NotNil(t, reply)
 	x, _ := services.Get(deployment.ServiceID)
-	assert.Equal(t, x, emptyService)
+	require.Equal(t, x, emptyService)
 }

--- a/api/core/deploy_test.go
+++ b/api/core/deploy_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mesg-foundation/core/database/services"
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var serverdeploy = new(Server)
@@ -23,8 +23,8 @@ func TestDeployService(t *testing.T) {
 	deployment, err := serverdeploy.DeployService(context.Background(), &DeployServiceRequest{
 		Service: &service,
 	})
-	assert.Nil(t, err)
-	assert.NotNil(t, deployment)
-	assert.NotEqual(t, "", deployment.ServiceID)
+	require.Nil(t, err)
+	require.NotNil(t, deployment)
+	require.NotEqual(t, "", deployment.ServiceID)
 	services.Delete(deployment.ServiceID)
 }

--- a/api/core/execute_test.go
+++ b/api/core/execute_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mesg-foundation/core/database/services"
 	"github.com/mesg-foundation/core/service"
+	"github.com/stretchr/testify/require"
 	"github.com/stvp/assert"
 )
 
@@ -35,8 +36,8 @@ func TestExecute(t *testing.T) {
 		InputData: "{}",
 	})
 
-	assert.Nil(t, err)
-	assert.NotNil(t, reply)
+	require.Nil(t, err)
+	require.NotNil(t, reply)
 }
 
 func TestExecuteWithInvalidJSON(t *testing.T) {
@@ -53,8 +54,9 @@ func TestExecuteWithInvalidJSON(t *testing.T) {
 		TaskKey:   "test",
 		InputData: "",
 	})
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "unexpected end of JSON input")
+
+	require.NotNil(t, err)
+	require.Equal(t, err.Error(), "unexpected end of JSON input")
 	services.Delete(deployment.ServiceID)
 }
 
@@ -82,9 +84,8 @@ func TestExecuteWithInvalidTask(t *testing.T) {
 		InputData: "{}",
 	})
 
-	assert.NotNil(t, err)
-	_, invalid := err.(*service.TaskNotFoundError)
-	assert.True(t, invalid)
+	require.Error(t, err)
+	require.IsType(t, (*service.TaskNotFoundError)(nil), err)
 }
 
 func TestExecuteWithNonRunningService(t *testing.T) {
@@ -104,9 +105,9 @@ func TestExecuteWithNonRunningService(t *testing.T) {
 		InputData: "{}",
 	})
 
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	_, nonRunning := err.(*NotRunningServiceError)
-	assert.True(t, nonRunning)
+	require.True(t, nonRunning)
 }
 
 func TestExecuteWithNonExistingService(t *testing.T) {
@@ -116,7 +117,7 @@ func TestExecuteWithNonExistingService(t *testing.T) {
 		InputData: "{}",
 	})
 
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestExecuteFunc(t *testing.T) {

--- a/api/core/get_service_test.go
+++ b/api/core/get_service_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mesg-foundation/core/database/services"
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var servergetservice = new(Server)
@@ -19,7 +19,7 @@ func TestGetService(t *testing.T) {
 	reply, err := servergetservice.GetService(context.Background(), &GetServiceRequest{
 		ServiceID: hash,
 	})
-	assert.Nil(t, err)
-	assert.NotNil(t, reply)
-	assert.Equal(t, reply.Service.Name, "TestGetService")
+	require.Nil(t, err)
+	require.NotNil(t, reply)
+	require.Equal(t, reply.Service.Name, "TestGetService")
 }

--- a/api/core/list_services_test.go
+++ b/api/core/list_services_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/database/services"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var serverlistservices = new(Server)
@@ -13,6 +13,6 @@ var serverlistservices = new(Server)
 func TestListServices(t *testing.T) {
 	servicesFromAPI, err := serverlistservices.ListServices(context.Background(), &ListServicesRequest{})
 	servicesFromDB, _ := services.All()
-	assert.Nil(t, err)
-	assert.Equal(t, len(servicesFromAPI.Services), len(servicesFromDB))
+	require.Nil(t, err)
+	require.Equal(t, len(servicesFromAPI.Services), len(servicesFromDB))
 }

--- a/api/core/listen_event_test.go
+++ b/api/core/listen_event_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/mesg-foundation/core/event"
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateEventKey(t *testing.T) {
@@ -14,26 +14,26 @@ func TestValidateEventKey(t *testing.T) {
 			"test": {},
 		},
 	}
-	assert.Nil(t, validateEventKey(s, ""))
-	assert.Nil(t, validateEventKey(s, "*"))
-	assert.Nil(t, validateEventKey(s, "test"))
-	assert.NotNil(t, validateEventKey(s, "xxx"))
+	require.Nil(t, validateEventKey(s, ""))
+	require.Nil(t, validateEventKey(s, "*"))
+	require.Nil(t, validateEventKey(s, "test"))
+	require.NotNil(t, validateEventKey(s, "xxx"))
 }
 
 func TestIsSubscribedEvent(t *testing.T) {
 	e := &event.Event{Key: "test"}
 	r := &ListenEventRequest{}
-	assert.True(t, isSubscribedEvent(r, e))
+	require.True(t, isSubscribedEvent(r, e))
 
 	r = &ListenEventRequest{EventFilter: ""}
-	assert.True(t, isSubscribedEvent(r, e))
+	require.True(t, isSubscribedEvent(r, e))
 
 	r = &ListenEventRequest{EventFilter: "*"}
-	assert.True(t, isSubscribedEvent(r, e))
+	require.True(t, isSubscribedEvent(r, e))
 
 	r = &ListenEventRequest{EventFilter: "test"}
-	assert.True(t, isSubscribedEvent(r, e))
+	require.True(t, isSubscribedEvent(r, e))
 
 	r = &ListenEventRequest{EventFilter: "xxx"}
-	assert.False(t, isSubscribedEvent(r, e))
+	require.False(t, isSubscribedEvent(r, e))
 }

--- a/api/core/listen_result_test.go
+++ b/api/core/listen_result_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/mesg-foundation/core/execution"
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateTaskKey(t *testing.T) {
@@ -14,10 +14,10 @@ func TestValidateTaskKey(t *testing.T) {
 			"test": {},
 		},
 	}
-	assert.Nil(t, validateTaskKey(s, ""))
-	assert.Nil(t, validateTaskKey(s, "*"))
-	assert.Nil(t, validateTaskKey(s, "test"))
-	assert.NotNil(t, validateTaskKey(s, "xxx"))
+	require.Nil(t, validateTaskKey(s, ""))
+	require.Nil(t, validateTaskKey(s, "*"))
+	require.Nil(t, validateTaskKey(s, "test"))
+	require.NotNil(t, validateTaskKey(s, "xxx"))
 }
 
 func TestValidateOutputKey(t *testing.T) {
@@ -30,48 +30,48 @@ func TestValidateOutputKey(t *testing.T) {
 			},
 		},
 	}
-	assert.Nil(t, validateOutputKey(s, "test", ""))
-	assert.Nil(t, validateOutputKey(s, "test", "*"))
-	assert.Nil(t, validateOutputKey(s, "test", "outputx"))
-	assert.NotNil(t, validateOutputKey(s, "test", "xxx"))
-	assert.Nil(t, validateOutputKey(s, "xxx", ""))
-	assert.Nil(t, validateOutputKey(s, "xxx", "*"))
-	assert.NotNil(t, validateOutputKey(s, "xxx", "outputX"))
-	assert.NotNil(t, validateOutputKey(s, "xxx", "xxx"))
+	require.Nil(t, validateOutputKey(s, "test", ""))
+	require.Nil(t, validateOutputKey(s, "test", "*"))
+	require.Nil(t, validateOutputKey(s, "test", "outputx"))
+	require.NotNil(t, validateOutputKey(s, "test", "xxx"))
+	require.Nil(t, validateOutputKey(s, "xxx", ""))
+	require.Nil(t, validateOutputKey(s, "xxx", "*"))
+	require.NotNil(t, validateOutputKey(s, "xxx", "outputX"))
+	require.NotNil(t, validateOutputKey(s, "xxx", "xxx"))
 }
 
 func TestIsSubscribedTask(t *testing.T) {
 	x := &execution.Execution{Task: "task"}
 	r := &ListenResultRequest{}
-	assert.True(t, isSubscribedTask(r, x))
+	require.True(t, isSubscribedTask(r, x))
 
 	r = &ListenResultRequest{TaskFilter: ""}
-	assert.True(t, isSubscribedTask(r, x))
+	require.True(t, isSubscribedTask(r, x))
 
 	r = &ListenResultRequest{TaskFilter: "*"}
-	assert.True(t, isSubscribedTask(r, x))
+	require.True(t, isSubscribedTask(r, x))
 
 	r = &ListenResultRequest{TaskFilter: "task"}
-	assert.True(t, isSubscribedTask(r, x))
+	require.True(t, isSubscribedTask(r, x))
 
 	r = &ListenResultRequest{TaskFilter: "xxx"}
-	assert.False(t, isSubscribedTask(r, x))
+	require.False(t, isSubscribedTask(r, x))
 }
 
 func TestIsSubscribedOutput(t *testing.T) {
 	x := &execution.Execution{Output: "output"}
 	r := &ListenResultRequest{}
-	assert.True(t, isSubscribedOutput(r, x))
+	require.True(t, isSubscribedOutput(r, x))
 
 	r = &ListenResultRequest{OutputFilter: ""}
-	assert.True(t, isSubscribedOutput(r, x))
+	require.True(t, isSubscribedOutput(r, x))
 
 	r = &ListenResultRequest{OutputFilter: "*"}
-	assert.True(t, isSubscribedOutput(r, x))
+	require.True(t, isSubscribedOutput(r, x))
 
 	r = &ListenResultRequest{OutputFilter: "output"}
-	assert.True(t, isSubscribedOutput(r, x))
+	require.True(t, isSubscribedOutput(r, x))
 
 	r = &ListenResultRequest{OutputFilter: "xxx"}
-	assert.False(t, isSubscribedOutput(r, x))
+	require.False(t, isSubscribedOutput(r, x))
 }

--- a/api/core/start_test.go
+++ b/api/core/start_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mesg-foundation/core/database/services"
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var serverstart = new(Server)
@@ -26,10 +26,10 @@ func TestStartService(t *testing.T) {
 	reply, err := serverstart.StartService(context.Background(), &StartServiceRequest{
 		ServiceID: deployment.ServiceID,
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	status, _ := s.Status()
-	assert.Equal(t, service.RUNNING, status)
-	assert.NotNil(t, reply)
+	require.Equal(t, service.RUNNING, status)
+	require.NotNil(t, reply)
 	s.Stop()
 	services.Delete(deployment.ServiceID)
 }

--- a/api/core/stop_test.go
+++ b/api/core/stop_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mesg-foundation/core/database/services"
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var serverstop = new(Server)
@@ -28,8 +28,8 @@ func TestStopService(t *testing.T) {
 		ServiceID: deployment.ServiceID,
 	})
 	status, _ := s.Status()
-	assert.Equal(t, service.STOPPED, status)
-	assert.Nil(t, err)
-	assert.NotNil(t, reply)
+	require.Equal(t, service.STOPPED, status)
+	require.Nil(t, err)
+	require.NotNil(t, reply)
 	services.Delete(deployment.ServiceID)
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -21,7 +21,7 @@ func TestServerServe(t *testing.T) {
 		s.Stop()
 	}()
 	err := s.Serve()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestServerServeNoAddress(t *testing.T) {
@@ -31,7 +31,7 @@ func TestServerServeNoAddress(t *testing.T) {
 		s.Stop()
 	}()
 	err := s.Serve()
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestServerServeAlreadyListening(t *testing.T) {
@@ -43,5 +43,5 @@ func TestServerServeAlreadyListening(t *testing.T) {
 	time.Sleep(waitForServe)
 	err := s.Serve()
 	defer s.Stop()
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }

--- a/api/service/emit_event_test.go
+++ b/api/service/emit_event_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mesg-foundation/core/database/services"
 	"github.com/mesg-foundation/core/pubsub"
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var serveremit = new(Server)
@@ -36,7 +36,7 @@ func TestEmit(t *testing.T) {
 	})
 
 	res := <-subscription
-	assert.NotNil(t, res)
+	require.NotNil(t, res)
 }
 
 func TestEmitNoData(t *testing.T) {
@@ -47,7 +47,7 @@ func TestEmitNoData(t *testing.T) {
 		Token:    service.Hash(),
 		EventKey: "test",
 	})
-	assert.Equal(t, err.Error(), "unexpected end of JSON input")
+	require.Equal(t, err.Error(), "unexpected end of JSON input")
 }
 
 func TestEmitWrongData(t *testing.T) {
@@ -59,7 +59,7 @@ func TestEmitWrongData(t *testing.T) {
 		EventKey:  "test",
 		EventData: "",
 	})
-	assert.Equal(t, err.Error(), "unexpected end of JSON input")
+	require.Equal(t, err.Error(), "unexpected end of JSON input")
 }
 
 func TestEmitWrongEvent(t *testing.T) {
@@ -71,9 +71,9 @@ func TestEmitWrongEvent(t *testing.T) {
 		EventKey:  "test",
 		EventData: "{}",
 	})
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	_, notFound := err.(*service.EventNotFoundError)
-	assert.True(t, notFound)
+	require.True(t, notFound)
 }
 
 func TestServiceNotExists(t *testing.T) {
@@ -83,5 +83,5 @@ func TestServiceNotExists(t *testing.T) {
 		EventKey:  "test",
 		EventData: "{}",
 	})
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }

--- a/api/service/error_test.go
+++ b/api/service/error_test.go
@@ -3,10 +3,10 @@ package service
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMissingExecutionError(t *testing.T) {
 	e := MissingExecutionError{ID: "test"}
-	assert.Equal(t, "Execution test doesn't exists", e.Error())
+	require.Equal(t, "Execution test doesn't exists", e.Error())
 }

--- a/api/service/submit_result_test.go
+++ b/api/service/submit_result_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mesg-foundation/core/execution"
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var serversubmit = new(Server)
@@ -35,8 +35,8 @@ func TestSubmit(t *testing.T) {
 		OutputData:  "{}",
 	})
 
-	assert.Nil(t, err)
-	assert.NotNil(t, reply)
+	require.Nil(t, err)
+	require.NotNil(t, reply)
 }
 
 func TestSubmitWithInvalidJSON(t *testing.T) {
@@ -47,7 +47,7 @@ func TestSubmitWithInvalidJSON(t *testing.T) {
 		OutputData:  "",
 	})
 
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestSubmitWithInvalidID(t *testing.T) {
@@ -56,8 +56,8 @@ func TestSubmitWithInvalidID(t *testing.T) {
 		OutputKey:   "output",
 		OutputData:  "",
 	})
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	x, missingExecutionError := err.(*MissingExecutionError)
-	assert.True(t, missingExecutionError)
-	assert.Equal(t, "xxxx", x.ID)
+	require.True(t, missingExecutionError)
+	require.Equal(t, "xxxx", x.ID)
 }

--- a/cmd/service/execute_test.go
+++ b/cmd/service/execute_test.go
@@ -4,20 +4,20 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadJSONFile(t *testing.T) {
 	d, e := readJSONFile("")
-	assert.Nil(t, e)
-	assert.Equal(t, "{}", d)
+	require.Nil(t, e)
+	require.Equal(t, "{}", d)
 
 	d, e = readJSONFile("./doesntexistsfile")
-	assert.NotNil(t, e)
+	require.NotNil(t, e)
 
 	d, e = readJSONFile("./tests/validData.json")
-	assert.Nil(t, e)
-	assert.Equal(t, "{\"foo\":\"bar\"}", d)
+	require.Nil(t, e)
+	require.Equal(t, "{\"foo\":\"bar\"}", d)
 }
 
 func TestTaskKeysFromService(t *testing.T) {
@@ -26,5 +26,5 @@ func TestTaskKeysFromService(t *testing.T) {
 			"task1": {},
 		},
 	})
-	assert.Equal(t, "task1", keys[0])
+	require.Equal(t, "task1", keys[0])
 }

--- a/cmd/service/init_test.go
+++ b/cmd/service/init_test.go
@@ -4,18 +4,18 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTemplate(t *testing.T) {
 	templates, err := getTemplates(templatesURL)
-	assert.Nil(t, err)
-	assert.True(t, len(templates) > 0)
+	require.Nil(t, err)
+	require.True(t, len(templates) > 0)
 }
 
 func TestGetTemplateBadURL(t *testing.T) {
 	_, err := getTemplates("...")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestTemplatesToOption(t *testing.T) {
@@ -24,15 +24,15 @@ func TestTemplatesToOption(t *testing.T) {
 		{Name: "yyy", URL: "https://..."},
 	}
 	options := templatesToOption(templates)
-	assert.Equal(t, len(options), len(templates)+2)
-	assert.Equal(t, options[0], "xxx (https://...)")
-	assert.Equal(t, options[1], "yyy (https://...)")
-	assert.Equal(t, options[2], custom)
-	assert.Equal(t, options[3], addMyOwn)
+	require.Equal(t, len(options), len(templates)+2)
+	require.Equal(t, options[0], "xxx (https://...)")
+	require.Equal(t, options[1], "yyy (https://...)")
+	require.Equal(t, options[2], custom)
+	require.Equal(t, options[3], addMyOwn)
 }
 
 func TestGetTemplateResultAddMyOwn(t *testing.T) {
-	assert.Nil(t, getTemplateResult(addMyOwn, []*templateStruct{}))
+	require.Nil(t, getTemplateResult(addMyOwn, []*templateStruct{}))
 }
 
 func TestGetTemplateResultAdd(t *testing.T) {
@@ -42,8 +42,8 @@ func TestGetTemplateResultAdd(t *testing.T) {
 	}
 	result := "yyy (https://...)"
 	tmpl := getTemplateResult(result, templates)
-	assert.NotNil(t, tmpl)
-	assert.Equal(t, tmpl.Name, templates[1].Name)
+	require.NotNil(t, tmpl)
+	require.Equal(t, tmpl.Name, templates[1].Name)
 }
 
 func TestDownloadTemplate(t *testing.T) {
@@ -52,6 +52,6 @@ func TestDownloadTemplate(t *testing.T) {
 	}
 	path, err := downloadTemplate(tmpl)
 	defer os.RemoveAll(path)
-	assert.Nil(t, err)
-	assert.NotNil(t, path)
+	require.Nil(t, err)
+	require.NotNil(t, path)
 }

--- a/cmd/service/list_test.go
+++ b/cmd/service/list_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServiceStatusString(t *testing.T) {
@@ -14,9 +14,9 @@ func TestServiceStatusString(t *testing.T) {
 		service: &s,
 		status:  service.RUNNING,
 	}
-	assert.Contains(t, "[Running]", status.String())
-	assert.Contains(t, s.Hash(), status.String())
-	assert.Contains(t, s.Name, status.String())
+	require.Contains(t, "[Running]", status.String())
+	require.Contains(t, s.Hash(), status.String())
+	require.Contains(t, s.Name, status.String())
 }
 
 func TestSort(t *testing.T) {
@@ -26,14 +26,14 @@ func TestSort(t *testing.T) {
 		{status: service.STOPPED, service: &service.Service{Name: "Stopped"}},
 	}
 	sort.Sort(byStatus(status))
-	assert.Equal(t, status[0].status, service.RUNNING)
-	assert.Equal(t, status[1].status, service.PARTIAL)
-	assert.Equal(t, status[2].status, service.STOPPED)
+	require.Equal(t, status[0].status, service.RUNNING)
+	require.Equal(t, status[1].status, service.PARTIAL)
+	require.Equal(t, status[2].status, service.STOPPED)
 }
 
 func TestServicesWithStatus(t *testing.T) {
 	services := append([]*service.Service{}, &service.Service{Name: "TestServicesWithStatus"})
 	status, err := servicesWithStatus(services)
-	assert.Nil(t, err)
-	assert.Equal(t, status[0].status, service.STOPPED)
+	require.Nil(t, err)
+	require.Equal(t, status[0].status, service.STOPPED)
 }

--- a/cmd/service/list_test.go
+++ b/cmd/service/list_test.go
@@ -14,9 +14,9 @@ func TestServiceStatusString(t *testing.T) {
 		service: &s,
 		status:  service.RUNNING,
 	}
-	require.Contains(t, "[Running]", status.String())
-	require.Contains(t, s.Hash(), status.String())
-	require.Contains(t, s.Name, status.String())
+	require.Contains(t, status.String(), "[Running]")
+	require.Contains(t, status.String(), s.Hash())
+	require.Contains(t, status.String(), s.Name)
 }
 
 func TestSort(t *testing.T) {

--- a/cmd/service/utils_test.go
+++ b/cmd/service/utils_test.go
@@ -5,33 +5,33 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 	git "gopkg.in/src-d/go-git.v4"
 )
 
 func TestDefaultPath(t *testing.T) {
-	assert.Equal(t, defaultPath([]string{}), "./")
-	assert.Equal(t, defaultPath([]string{"foo"}), "foo")
-	assert.Equal(t, defaultPath([]string{"foo", "bar"}), "foo")
+	require.Equal(t, defaultPath([]string{}), "./")
+	require.Equal(t, defaultPath([]string{"foo"}), "foo")
+	require.Equal(t, defaultPath([]string{"foo", "bar"}), "foo")
 }
 
 func TestBuildDockerImagePathDoNotExist(t *testing.T) {
 	_, err := buildDockerImage("/doNotExist")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestGitCloneRepositoryDoNotExist(t *testing.T) {
 	path, _ := createTempFolder()
 	defer os.RemoveAll(path)
 	err := gitClone("/doNotExist", path, "testing...")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestGitCloneWithoutURLSchema(t *testing.T) {
 	path, _ := createTempFolder()
 	defer os.RemoveAll(path)
 	err := gitClone("github.com/mesg-foundation/awesome.git", path, "testing...")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestGitCloneCustomBranch(t *testing.T) {
@@ -39,56 +39,56 @@ func TestGitCloneCustomBranch(t *testing.T) {
 	path, _ := createTempFolder()
 	defer os.RemoveAll(path)
 	err := gitClone("github.com/mesg-foundation/service-ethereum-erc20#"+branchName, path, "testing...")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	repo, err := git.PlainOpen(path)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	branch, err := repo.Branch(branchName)
-	assert.Nil(t, err)
-	assert.NotNil(t, branch)
+	require.Nil(t, err)
+	require.NotNil(t, branch)
 }
 
 func TestDownloadServiceIfNeededAbsolutePath(t *testing.T) {
 	path := "/users/paul/service-js-function"
 	newPath, didDownload, err := downloadServiceIfNeeded(path)
-	assert.Nil(t, err)
-	assert.Equal(t, path, newPath)
-	assert.Equal(t, false, didDownload)
+	require.Nil(t, err)
+	require.Equal(t, path, newPath)
+	require.Equal(t, false, didDownload)
 }
 
 func TestDownloadServiceIfNeededRelativePath(t *testing.T) {
 	path := "./service-js-function"
 	newPath, didDownload, err := downloadServiceIfNeeded(path)
-	assert.Nil(t, err)
-	assert.Equal(t, path, newPath)
-	assert.Equal(t, false, didDownload)
+	require.Nil(t, err)
+	require.Equal(t, path, newPath)
+	require.Equal(t, false, didDownload)
 }
 
 func TestDownloadServiceIfNeededUrl(t *testing.T) {
 	path := "https://github.com/mesg-foundation/awesome.git"
 	newPath, didDownload, err := downloadServiceIfNeeded(path)
 	defer os.RemoveAll(newPath)
-	assert.Nil(t, err)
-	assert.NotEqual(t, path, newPath)
-	assert.Equal(t, true, didDownload)
+	require.Nil(t, err)
+	require.NotEqual(t, path, newPath)
+	require.Equal(t, true, didDownload)
 }
 
 func TestCreateTempFolder(t *testing.T) {
 	path, err := createTempFolder()
 	defer os.RemoveAll(path)
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", path)
+	require.Nil(t, err)
+	require.NotEqual(t, "", path)
 }
 
 func TestRemoveTempFolder(t *testing.T) {
 	path, _ := createTempFolder()
 	err := os.RemoveAll(path)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestInjectConfigurationInDependencies(t *testing.T) {
 	s := &service.Service{}
 	injectConfigurationInDependencies(s, "TestInjectConfigurationInDependencies")
-	assert.Equal(t, s.Dependencies["service"].Image, "TestInjectConfigurationInDependencies")
+	require.Equal(t, s.Dependencies["service"].Image, "TestInjectConfigurationInDependencies")
 }
 
 func TestInjectConfigurationInDependenciesWithConfig(t *testing.T) {
@@ -99,8 +99,8 @@ func TestInjectConfigurationInDependenciesWithConfig(t *testing.T) {
 		},
 	}
 	injectConfigurationInDependencies(s, "TestInjectConfigurationInDependenciesWithConfig")
-	assert.Equal(t, s.Dependencies["service"].Image, "TestInjectConfigurationInDependenciesWithConfig")
-	assert.Equal(t, s.Dependencies["service"].Command, "xxx")
+	require.Equal(t, s.Dependencies["service"].Image, "TestInjectConfigurationInDependenciesWithConfig")
+	require.Equal(t, s.Dependencies["service"].Command, "xxx")
 }
 
 func TestInjectConfigurationInDependenciesWithDependency(t *testing.T) {
@@ -112,8 +112,8 @@ func TestInjectConfigurationInDependenciesWithDependency(t *testing.T) {
 		},
 	}
 	injectConfigurationInDependencies(s, "TestInjectConfigurationInDependenciesWithDependency")
-	assert.Equal(t, s.Dependencies["service"].Image, "TestInjectConfigurationInDependenciesWithDependency")
-	assert.Equal(t, s.Dependencies["test"].Image, "xxx")
+	require.Equal(t, s.Dependencies["service"].Image, "TestInjectConfigurationInDependenciesWithDependency")
+	require.Equal(t, s.Dependencies["test"].Image, "xxx")
 }
 
 func TestInjectConfigurationInDependenciesWithDependencyOverride(t *testing.T) {
@@ -125,5 +125,5 @@ func TestInjectConfigurationInDependenciesWithDependencyOverride(t *testing.T) {
 		},
 	}
 	injectConfigurationInDependencies(s, "TestInjectConfigurationInDependenciesWithDependencyOverride")
-	assert.Equal(t, s.Dependencies["service"].Image, "TestInjectConfigurationInDependenciesWithDependencyOverride")
+	require.Equal(t, s.Dependencies["service"].Image, "TestInjectConfigurationInDependenciesWithDependencyOverride")
 }

--- a/cmd/utils/error_test.go
+++ b/cmd/utils/error_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/client"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -14,23 +14,23 @@ var testCoreConnectionErr = status.Error(codes.Unavailable, "test")
 var testDockerConnectionErr = client.ErrorConnectionFailed("test")
 
 func TestCoreConnectionError(t *testing.T) {
-	assert.True(t, coreConnectionError(testCoreConnectionErr))
-	assert.False(t, coreConnectionError(nil))
-	assert.False(t, coreConnectionError(errors.New("test")))
+	require.True(t, coreConnectionError(testCoreConnectionErr))
+	require.False(t, coreConnectionError(nil))
+	require.False(t, coreConnectionError(errors.New("test")))
 }
 
 func TestDockerDaemonError(t *testing.T) {
-	assert.True(t, dockerDaemonError(testDockerConnectionErr))
-	assert.False(t, dockerDaemonError(nil))
-	assert.False(t, dockerDaemonError(errors.New("test")))
+	require.True(t, dockerDaemonError(testDockerConnectionErr))
+	require.False(t, dockerDaemonError(nil))
+	require.False(t, dockerDaemonError(errors.New("test")))
 }
 
 func TestErrorMessage(t *testing.T) {
-	assert.Contains(t, cannotReachTheCore, errorMessage(testCoreConnectionErr))
-	assert.Contains(t, startCore, errorMessage(testCoreConnectionErr))
+	require.Contains(t, cannotReachTheCore, errorMessage(testCoreConnectionErr))
+	require.Contains(t, startCore, errorMessage(testCoreConnectionErr))
 
-	assert.Contains(t, cannotReachDocker, errorMessage(testDockerConnectionErr))
-	assert.Contains(t, installDocker, errorMessage(testDockerConnectionErr))
+	require.Contains(t, cannotReachDocker, errorMessage(testDockerConnectionErr))
+	require.Contains(t, installDocker, errorMessage(testDockerConnectionErr))
 
-	assert.Contains(t, "errorX", errorMessage(errors.New("errorX")))
+	require.Contains(t, "errorX", errorMessage(errors.New("errorX")))
 }

--- a/cmd/utils/error_test.go
+++ b/cmd/utils/error_test.go
@@ -26,11 +26,11 @@ func TestDockerDaemonError(t *testing.T) {
 }
 
 func TestErrorMessage(t *testing.T) {
-	require.Contains(t, cannotReachTheCore, errorMessage(testCoreConnectionErr))
-	require.Contains(t, startCore, errorMessage(testCoreConnectionErr))
+	require.Contains(t, errorMessage(testCoreConnectionErr), cannotReachTheCore)
+	require.Contains(t, errorMessage(testCoreConnectionErr), startCore)
 
-	require.Contains(t, cannotReachDocker, errorMessage(testDockerConnectionErr))
-	require.Contains(t, installDocker, errorMessage(testDockerConnectionErr))
+	require.Contains(t, errorMessage(testDockerConnectionErr), cannotReachDocker)
+	require.Contains(t, errorMessage(testDockerConnectionErr), installDocker)
 
-	require.Contains(t, "errorX", errorMessage(errors.New("errorX")))
+	require.Contains(t, errorMessage(errors.New("errorX")), "errorX")
 }

--- a/config/api_test.go
+++ b/config/api_test.go
@@ -29,5 +29,5 @@ func TestAPIDefault(t *testing.T) {
 	}
 
 	// Override by ENV when testing, so only test the image name
-	require.Contains(t, "mesg/core:", viper.GetString(CoreImage))
+	require.Contains(t, viper.GetString(CoreImage), "mesg/core:")
 }

--- a/config/api_test.go
+++ b/config/api_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func assertViperDefault(t *testing.T, key string, expected string) {
 	value := viper.GetString(key)
-	assert.Equal(t, expected, value, "Wrong default for key "+key)
+	require.Equal(t, expected, value, "Wrong default for key "+key)
 }
 
 func TestAPIDefault(t *testing.T) {
@@ -29,5 +29,5 @@ func TestAPIDefault(t *testing.T) {
 	}
 
 	// Override by ENV when testing, so only test the image name
-	assert.Contains(t, "mesg/core:", viper.GetString(CoreImage))
+	require.Contains(t, "mesg/core:", viper.GetString(CoreImage))
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,9 +3,9 @@ package config
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToEnv(t *testing.T) {
-	assert.Equal(t, envPrefix+envSeparator+"FOO"+envSeparator+"BAR", ToEnv("foo.bar"))
+	require.Equal(t, envPrefix+envSeparator+"FOO"+envSeparator+"BAR", ToEnv("foo.bar"))
 }

--- a/config/directory_test.go
+++ b/config/directory_test.go
@@ -5,17 +5,17 @@ import (
 	"testing"
 
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateConfigPath(t *testing.T) {
 	err := createConfigPath()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestConfigPath(t *testing.T) {
 	homePath, _ := homedir.Dir()
 	dir, err := getConfigPath()
-	assert.Nil(t, err)
-	assert.Equal(t, dir, filepath.Join(homePath, configDirectory))
+	require.Nil(t, err)
+	require.Equal(t, dir, filepath.Join(homePath, configDirectory))
 }

--- a/container/build_integration_test.go
+++ b/container/build_integration_test.go
@@ -5,28 +5,28 @@ package container
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationBuild(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	tag, err := c.Build("test/")
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", tag)
+	require.Nil(t, err)
+	require.NotEqual(t, "", tag)
 }
 
 func TestIntegrationBuildNotWorking(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	tag, err := c.Build("test-not-valid/")
-	assert.NotNil(t, err)
-	assert.Equal(t, "", tag)
+	require.NotNil(t, err)
+	require.Equal(t, "", tag)
 }
 
 func TestIntegrationBuildWrongPath(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	_, err = c.Build("testss/")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }

--- a/container/build_test.go
+++ b/container/build_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/mesg-foundation/core/container/dockertest"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuild(t *testing.T) {
@@ -23,12 +23,12 @@ func TestBuild(t *testing.T) {
 	)), nil)
 
 	tag1, err := c.Build(path)
-	assert.Nil(t, err)
-	assert.Equal(t, tag, tag1)
+	require.Nil(t, err)
+	require.Equal(t, tag, tag1)
 
 	li := <-dt.LastImageBuild()
-	assert.True(t, len(li.FileData) > 0)
-	assert.Equal(t, types.ImageBuildOptions{
+	require.True(t, len(li.FileData) > 0)
+	require.Equal(t, types.ImageBuildOptions{
 		Remove:         true,
 		ForceRemove:    true,
 		SuppressOutput: true,
@@ -47,8 +47,8 @@ func TestBuildNotWorking(t *testing.T) {
 {"errorDetail":{"message":"invalid reference format: repository name must be lowercase"},"error":"invalid reference format: repository name must be lowercase"}`)), nil)
 
 	tag, err := c.Build(path)
-	assert.Equal(t, "Image build failed. invalid reference format: repository name must be lowercase", err.Error())
-	assert.Equal(t, "", tag)
+	require.Equal(t, "Image build failed. invalid reference format: repository name must be lowercase", err.Error())
+	require.Equal(t, "", tag)
 }
 
 func TestBuildWrongPath(t *testing.T) {
@@ -58,7 +58,7 @@ func TestBuildWrongPath(t *testing.T) {
 	dt.ProvideImageBuild(ioutil.NopCloser(strings.NewReader("")), nil)
 
 	_, err := c.Build("testss/")
-	assert.Equal(t, "Could not parse container build response", err.Error())
+	require.Equal(t, "Could not parse container build response", err.Error())
 }
 
 func TestParseBuildResponseInvalidJSON(t *testing.T) {
@@ -67,7 +67,7 @@ func TestParseBuildResponseInvalidJSON(t *testing.T) {
 		Body: body,
 	}
 	_, err := parseBuildResponse(response)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestParseBuildResponse(t *testing.T) {
@@ -76,8 +76,8 @@ func TestParseBuildResponse(t *testing.T) {
 		Body: body,
 	}
 	tag, err := parseBuildResponse(response)
-	assert.Nil(t, err)
-	assert.Equal(t, tag, "ok")
+	require.Nil(t, err)
+	require.Equal(t, tag, "ok")
 }
 
 func TestParseBuildResponseWithNewLine(t *testing.T) {
@@ -86,6 +86,6 @@ func TestParseBuildResponseWithNewLine(t *testing.T) {
 		Body: body,
 	}
 	tag, err := parseBuildResponse(response)
-	assert.Nil(t, err)
-	assert.Equal(t, tag, "ok")
+	require.Nil(t, err)
+	require.Equal(t, tag, "ok")
 }

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -5,15 +5,15 @@ package container
 // 	leaveSwarm()
 // 	dockerClient, _ := godocker.NewClientFromEnv()
 // 	ID, err := createSwarm(dockerClient)
-// 	assert.Nil(t, err)
-// 	assert.NotEqual(t, ID, "")
+// 	require.Nil(t, err)
+// 	require.NotEqual(t, ID, "")
 // }
 
 // func TestClientWithCreateSwarm(t *testing.T) {
 // 	leaveSwarm()
 // 	client, err := Client()
-// 	assert.Nil(t, err)
-// 	assert.NotNil(t, client)
+// 	require.Nil(t, err)
+// 	require.NotNil(t, client)
 // }
 
 // func leaveSwarm() {

--- a/container/container_integration_test.go
+++ b/container/container_integration_test.go
@@ -5,74 +5,74 @@ package container
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationCreateSwarmIfNeeded(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
-	assert.Nil(t, c.createSwarmIfNeeded())
+	require.Nil(t, err)
+	require.Nil(t, c.createSwarmIfNeeded())
 }
 
 func TestIntegrationFindContainerNotExisting(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	_, err = c.FindContainer([]string{"TestFindContainerNotExisting"})
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestIntegrationFindContainer(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestFindContainer"}
 	startTestService(namespace)
 	defer c.StopService(namespace)
 	c.waitForStatus(namespace, RUNNING)
 	container, err := c.FindContainer(namespace)
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", container.ID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", container.ID)
 }
 
 func TestIntegrationFindContainerStopped(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestFindContainerStopped"}
 	startTestService(namespace)
 	c.StopService(namespace)
 	_, err = c.FindContainer(namespace)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestIntegrationContainerStatusNeverStarted(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestContainerStatusNeverStarted"}
 	status, err := c.Status(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, status, STOPPED)
+	require.Nil(t, err)
+	require.Equal(t, status, STOPPED)
 }
 
 func TestIntegrationContainerStatusRunning(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestContainerStatusRunning"}
 	startTestService(namespace)
 	defer c.StopService(namespace)
 	c.waitForStatus(namespace, RUNNING)
 	status, err := c.Status(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, status, RUNNING)
+	require.Nil(t, err)
+	require.Equal(t, status, RUNNING)
 }
 
 func TestIntegrationContainerStatusStopped(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestContainerStatusStopped"}
 	startTestService(namespace)
 	c.waitForStatus(namespace, RUNNING)
 	c.StopService(namespace)
 	c.waitForStatus(namespace, STOPPED)
 	status, err := c.Status(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, status, STOPPED)
+	require.Nil(t, err)
+	require.Equal(t, status, STOPPED)
 }

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 
 	"github.com/mesg-foundation/core/container/dockertest"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
 	dt := dockertest.New()
 	c, err := New(ClientOption(dt.Client()))
-	assert.Nil(t, err)
-	assert.NotNil(t, c)
+	require.Nil(t, err)
+	require.NotNil(t, c)
 
 	select {
 	case <-dt.LastNegotiateAPIVersion():
@@ -29,11 +29,11 @@ func TestNew(t *testing.T) {
 		t.Error("should fetch info")
 	}
 
-	assert.Equal(t, "0.0.0.0:2377", (<-dt.LastSwarmInit()).Request.ListenAddr)
+	require.Equal(t, "0.0.0.0:2377", (<-dt.LastSwarmInit()).Request.ListenAddr)
 
 	ln := <-dt.LastNetworkCreate()
-	assert.Equal(t, "mesg-shared", ln.Name)
-	assert.Equal(t, types.NetworkCreate{
+	require.Equal(t, "mesg-shared", ln.Name)
+	require.Equal(t, types.NetworkCreate{
 		CheckDuplicate: true,
 		Driver:         "overlay",
 		Labels: map[string]string{
@@ -47,8 +47,8 @@ func TestNewWithExistingNode(t *testing.T) {
 	dt.ProvideInfo(types.Info{Swarm: swarm.Info{NodeID: "1"}}, nil)
 
 	c, err := New(ClientOption(dt.Client()))
-	assert.Nil(t, err)
-	assert.NotNil(t, c)
+	require.Nil(t, err)
+	require.NotNil(t, c)
 
 	select {
 	case <-dt.LastSwarmInit():
@@ -66,9 +66,9 @@ func TestFindContainerNonExistent(t *testing.T) {
 	dt.ProvideContainerList(nil, dockertest.NotFoundErr{})
 
 	_, err := c.FindContainer(namespace)
-	assert.Equal(t, dockertest.NotFoundErr{}, err)
+	require.Equal(t, dockertest.NotFoundErr{}, err)
 
-	assert.Equal(t, types.ContainerListOptions{
+	require.Equal(t, types.ContainerListOptions{
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: "com.docker.stack.namespace=" + Namespace(namespace),
@@ -96,10 +96,10 @@ func TestFindContainer(t *testing.T) {
 	dt.ProvideContainerInspect(containerJSONData, nil)
 
 	container, err := c.FindContainer(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, containerJSONData.ID, container.ID)
+	require.Nil(t, err)
+	require.Equal(t, containerJSONData.ID, container.ID)
 
-	assert.Equal(t, types.ContainerListOptions{
+	require.Equal(t, types.ContainerListOptions{
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: "com.docker.stack.namespace=" + Namespace(namespace),
@@ -107,7 +107,7 @@ func TestFindContainer(t *testing.T) {
 		Limit: 1,
 	}, (<-dt.LastContainerList()).Options)
 
-	assert.Equal(t, containerID, (<-dt.LastContainerInspect()).Container)
+	require.Equal(t, containerID, (<-dt.LastContainerInspect()).Container)
 }
 
 func TestNonExistentContainerStatus(t *testing.T) {
@@ -119,10 +119,10 @@ func TestNonExistentContainerStatus(t *testing.T) {
 	dt.ProvideContainerList(nil, dockertest.NotFoundErr{})
 
 	status, err := c.Status(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, STOPPED, status)
+	require.Nil(t, err)
+	require.Equal(t, STOPPED, status)
 
-	assert.Equal(t, types.ContainerListOptions{
+	require.Equal(t, types.ContainerListOptions{
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: "com.docker.stack.namespace=" + Namespace(namespace),
@@ -151,8 +151,8 @@ func TestExistentContainerStatus(t *testing.T) {
 	dt.ProvideContainerInspect(containerJSONData, nil)
 
 	status, err := c.Status(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, STOPPED, status)
+	require.Nil(t, err)
+	require.Equal(t, STOPPED, status)
 }
 
 func TestExistentContainerRunningStatus(t *testing.T) {
@@ -175,6 +175,6 @@ func TestExistentContainerRunningStatus(t *testing.T) {
 	dt.ProvideContainerInspect(containerJSONData, nil)
 
 	status, err := c.Status(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, RUNNING, status)
+	require.Nil(t, err)
+	require.Equal(t, RUNNING, status)
 }

--- a/container/dockertest/error_test.go
+++ b/container/dockertest/error_test.go
@@ -3,12 +3,12 @@ package dockertest
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNotFoundErr makes sure NotFoundErr to implement docker client's notFound interface.
 func TestNotFoundErr(t *testing.T) {
 	err := NotFoundErr{}
-	assert.True(t, err.NotFound())
-	assert.Equal(t, "not found", err.Error())
+	require.True(t, err.NotFound())
+	require.Equal(t, "not found", err.Error())
 }

--- a/container/dockertest/testing_test.go
+++ b/container/dockertest/testing_test.go
@@ -10,19 +10,19 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var errGeneric = errors.New("titan of the errors")
 
 func TestNew(t *testing.T) {
 	dt := New()
-	assert.NotNil(t, dt)
+	require.NotNil(t, dt)
 }
 
 func TestClient(t *testing.T) {
 	dt := New()
-	assert.NotNil(t, dt.Client())
+	require.NotNil(t, dt.Client())
 }
 
 func TestNegotiateAPIVersion(t *testing.T) {
@@ -45,12 +45,12 @@ func TestNetworkInspect(t *testing.T) {
 	dt.ProvideNetworkInspect(resource, errGeneric)
 
 	resource1, err := dt.Client().NetworkInspect(context.Background(), network, options)
-	assert.Equal(t, errGeneric, err)
-	assert.Equal(t, resource, resource1)
+	require.Equal(t, errGeneric, err)
+	require.Equal(t, resource, resource1)
 
 	ll := <-dt.LastNetworkInspect()
-	assert.Equal(t, network, ll.Network)
-	assert.Equal(t, options, ll.Options)
+	require.Equal(t, network, ll.Network)
+	require.Equal(t, options, ll.Options)
 }
 
 func TestNetworkCreate(t *testing.T) {
@@ -62,12 +62,12 @@ func TestNetworkCreate(t *testing.T) {
 	dt.ProvideNetworkCreate(response, errGeneric)
 
 	response1, err := dt.Client().NetworkCreate(context.Background(), name, options)
-	assert.Equal(t, errGeneric, err)
-	assert.Equal(t, response, response1)
+	require.Equal(t, errGeneric, err)
+	require.Equal(t, response, response1)
 
 	ll := <-dt.LastNetworkCreate()
-	assert.Equal(t, name, ll.Name)
-	assert.Equal(t, options, ll.Options)
+	require.Equal(t, name, ll.Name)
+	require.Equal(t, options, ll.Options)
 }
 
 func TestSwarmInit(t *testing.T) {
@@ -76,10 +76,10 @@ func TestSwarmInit(t *testing.T) {
 	dt := New()
 
 	data, err := dt.Client().SwarmInit(context.Background(), request)
-	assert.Nil(t, err)
-	assert.Equal(t, "", data)
+	require.Nil(t, err)
+	require.Equal(t, "", data)
 
-	assert.Equal(t, request, (<-dt.LastSwarmInit()).Request)
+	require.Equal(t, request, (<-dt.LastSwarmInit()).Request)
 }
 
 func TestInfo(t *testing.T) {
@@ -89,8 +89,8 @@ func TestInfo(t *testing.T) {
 	dt.ProvideInfo(info, errGeneric)
 
 	info1, err := dt.Client().Info(context.Background())
-	assert.Equal(t, errGeneric, err)
-	assert.Equal(t, info, info1)
+	require.Equal(t, errGeneric, err)
+	require.Equal(t, info, info1)
 
 	select {
 	case <-dt.LastInfo():
@@ -107,11 +107,11 @@ func TestContainerList(t *testing.T) {
 	dt.ProvideContainerList(containers, errGeneric)
 
 	containers1, err := dt.Client().ContainerList(context.Background(), options)
-	assert.Equal(t, errGeneric, err)
-	assert.Equal(t, containers, containers1)
+	require.Equal(t, errGeneric, err)
+	require.Equal(t, containers, containers1)
 
 	ll := <-dt.LastContainerList()
-	assert.Equal(t, options, ll.Options)
+	require.Equal(t, options, ll.Options)
 }
 
 func TestContainerInspect(t *testing.T) {
@@ -122,11 +122,11 @@ func TestContainerInspect(t *testing.T) {
 	dt.ProvideContainerInspect(containerJSON, errGeneric)
 
 	containerJSON1, err := dt.Client().ContainerInspect(context.Background(), container)
-	assert.Equal(t, errGeneric, err)
-	assert.Equal(t, containerJSON, containerJSON1)
+	require.Equal(t, errGeneric, err)
+	require.Equal(t, containerJSON, containerJSON1)
 
 	ll := <-dt.LastContainerInspect()
-	assert.Equal(t, container, ll.Container)
+	require.Equal(t, container, ll.Container)
 }
 
 func TestImageBuild(t *testing.T) {
@@ -139,23 +139,23 @@ func TestImageBuild(t *testing.T) {
 
 	resp, err := dt.Client().ImageBuild(context.Background(),
 		ioutil.NopCloser(bytes.NewReader(request)), options)
-	assert.Equal(t, errGeneric, err)
+	require.Equal(t, errGeneric, err)
 	defer resp.Body.Close()
 
 	respData, err := ioutil.ReadAll(resp.Body)
-	assert.Nil(t, err)
-	assert.Equal(t, response, respData)
+	require.Nil(t, err)
+	require.Equal(t, response, respData)
 
 	ll := <-dt.LastImageBuild()
-	assert.Equal(t, options, ll.Options)
-	assert.Equal(t, request, ll.FileData)
+	require.Equal(t, options, ll.Options)
+	require.Equal(t, request, ll.FileData)
 }
 
 func TestNetworkRemove(t *testing.T) {
 	network := "1"
 	dt := New()
-	assert.Nil(t, dt.Client().NetworkRemove(context.Background(), network))
-	assert.Equal(t, network, (<-dt.LastNetworkRemove()).Network)
+	require.Nil(t, dt.Client().NetworkRemove(context.Background(), network))
+	require.Equal(t, network, (<-dt.LastNetworkRemove()).Network)
 }
 
 func TestTaskList(t *testing.T) {
@@ -170,10 +170,10 @@ func TestTaskList(t *testing.T) {
 	dt.ProvideTaskList(tasks, errGeneric)
 
 	tasks1, err := dt.Client().TaskList(context.Background(), options)
-	assert.Equal(t, errGeneric, err)
-	assert.Equal(t, tasks, tasks1)
+	require.Equal(t, errGeneric, err)
+	require.Equal(t, tasks, tasks1)
 
-	assert.Equal(t, options, (<-dt.LastTaskList()).Options)
+	require.Equal(t, options, (<-dt.LastTaskList()).Options)
 }
 
 func TestServiceCreate(t *testing.T) {
@@ -185,12 +185,12 @@ func TestServiceCreate(t *testing.T) {
 	dt.ProvideServiceCreate(response, errGeneric)
 
 	response1, err := dt.Client().ServiceCreate(context.Background(), service, options)
-	assert.Equal(t, errGeneric, err)
-	assert.Equal(t, response, response1)
+	require.Equal(t, errGeneric, err)
+	require.Equal(t, response, response1)
 
 	ll := <-dt.LastServiceCreate()
-	assert.Equal(t, service, ll.Service)
-	assert.Equal(t, options, ll.Options)
+	require.Equal(t, service, ll.Service)
+	require.Equal(t, options, ll.Options)
 }
 
 func TestServiceList(t *testing.T) {
@@ -205,11 +205,11 @@ func TestServiceList(t *testing.T) {
 	dt.ProvideServiceList(services, errGeneric)
 
 	services1, err := dt.Client().ServiceList(context.Background(), options)
-	assert.Equal(t, errGeneric, err)
-	assert.Equal(t, services, services1)
+	require.Equal(t, errGeneric, err)
+	require.Equal(t, services, services1)
 
 	ll := <-dt.LastServiceList()
-	assert.Equal(t, options, ll.Options)
+	require.Equal(t, options, ll.Options)
 }
 
 func TestServiceInspectWithRaw(t *testing.T) {
@@ -222,13 +222,13 @@ func TestServiceInspectWithRaw(t *testing.T) {
 	dt.ProvideServiceInspectWithRaw(service, data, errGeneric)
 
 	service1, data1, err := dt.Client().ServiceInspectWithRaw(context.Background(), serviceID, options)
-	assert.Equal(t, errGeneric, err)
-	assert.Equal(t, service, service1)
-	assert.Equal(t, data, data1)
+	require.Equal(t, errGeneric, err)
+	require.Equal(t, service, service1)
+	require.Equal(t, data, data1)
 
 	ll := <-dt.LastServiceInspectWithRaw()
-	assert.Equal(t, serviceID, ll.ServiceID)
-	assert.Equal(t, options, ll.Options)
+	require.Equal(t, serviceID, ll.ServiceID)
+	require.Equal(t, options, ll.Options)
 }
 
 func TestServiceRemove(t *testing.T) {
@@ -237,10 +237,10 @@ func TestServiceRemove(t *testing.T) {
 	dt := New()
 	dt.ProvideServiceRemove(errGeneric)
 
-	assert.Equal(t, errGeneric, dt.Client().ServiceRemove(context.Background(), serviceID))
+	require.Equal(t, errGeneric, dt.Client().ServiceRemove(context.Background(), serviceID))
 
 	ll := <-dt.LastServiceRemove()
-	assert.Equal(t, serviceID, ll.ServiceID)
+	require.Equal(t, serviceID, ll.ServiceID)
 }
 
 func TestServiceLogs(t *testing.T) {
@@ -252,14 +252,14 @@ func TestServiceLogs(t *testing.T) {
 	dt.ProvideServiceLogs(ioutil.NopCloser(bytes.NewReader(data)), errGeneric)
 
 	rc, err := dt.Client().ServiceLogs(context.Background(), serviceID, options)
-	assert.Equal(t, errGeneric, err)
+	require.Equal(t, errGeneric, err)
 	defer rc.Close()
 
 	data1, err := ioutil.ReadAll(rc)
-	assert.Nil(t, err)
-	assert.Equal(t, data, data1)
+	require.Nil(t, err)
+	require.Equal(t, data, data1)
 
 	ll := <-dt.LastServiceLogs()
-	assert.Equal(t, serviceID, ll.ServiceID)
-	assert.Equal(t, options, ll.Options)
+	require.Equal(t, serviceID, ll.ServiceID)
+	require.Equal(t, options, ll.Options)
 }

--- a/container/namespace_test.go
+++ b/container/namespace_test.go
@@ -4,15 +4,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNamespace(t *testing.T) {
 	namespace := Namespace([]string{"test"})
-	assert.Equal(t, namespace, strings.Join([]string{namespacePrefix, "test"}, namespaceSeparator))
+	require.Equal(t, namespace, strings.Join([]string{namespacePrefix, "test"}, namespaceSeparator))
 }
 
 func TestNamespaceReplaceSpace(t *testing.T) {
 	namespace := Namespace([]string{"test foo"})
-	assert.Equal(t, namespace, strings.Join([]string{namespacePrefix, "test-foo"}, namespaceSeparator))
+	require.Equal(t, namespace, strings.Join([]string{namespacePrefix, "test-foo"}, namespaceSeparator))
 }

--- a/container/network_integration_test.go
+++ b/container/network_integration_test.go
@@ -5,65 +5,65 @@ package container
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationCreateNetwork(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	networkID, err := c.CreateNetwork([]string{"TestCreateNetwork"})
 	defer c.DeleteNetwork([]string{"TestCreateNetwork"})
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", networkID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", networkID)
 }
 
 func TestIntegrationCreateAlreadyExistingNetwork(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	c.CreateNetwork([]string{"TestCreateAlreadyExistingNetwork"})
 	networkID, err := c.CreateNetwork([]string{"TestCreateAlreadyExistingNetwork"})
 	defer c.DeleteNetwork([]string{"TestCreateAlreadyExistingNetwork"})
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", networkID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", networkID)
 }
 
 func TestIntegrationDeleteNetwork(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	c.CreateNetwork([]string{"TestDeleteNetwork"})
 	err = c.DeleteNetwork([]string{"TestDeleteNetwork"})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestIntegrationDeleteNotExistingNetwork(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	err = c.DeleteNetwork([]string{"TestDeleteNotExistingNetwork"})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestIntegrationFindNetwork(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	c.CreateNetwork([]string{"TestFindNetwork"})
 	defer c.DeleteNetwork([]string{"TestFindNetwork"})
 	network, err := c.FindNetwork([]string{"TestFindNetwork"})
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", network.ID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", network.ID)
 }
 
 func TestIntegrationFindNotExistingNetwork(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	_, err = c.FindNetwork([]string{"TestFindNotExistingNetwork"})
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestIntegrationFindDeletedNetwork(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	c.CreateNetwork([]string{"TestFindDeletedNetwork"})
 	c.DeleteNetwork([]string{"TestFindDeletedNetwork"})
 	_, err = c.FindNetwork([]string{"TestFindDeletedNetwork"})
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }

--- a/container/network_test.go
+++ b/container/network_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/mesg-foundation/core/container/dockertest"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateNetwork(t *testing.T) {
@@ -24,12 +24,12 @@ func TestCreateNetwork(t *testing.T) {
 	dt.ProvideNetworkInspect(types.NetworkResource{}, nil)
 
 	networkID, err := c.CreateNetwork(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, id, networkID)
+	require.Nil(t, err)
+	require.Equal(t, id, networkID)
 
 	li := <-dt.LastNetworkCreate()
-	assert.Equal(t, Namespace(namespace), li.Name)
-	assert.Equal(t, types.NetworkCreate{
+	require.Equal(t, Namespace(namespace), li.Name)
+	require.Equal(t, types.NetworkCreate{
 		CheckDuplicate: true,
 		Driver:         "overlay",
 		Labels: map[string]string{
@@ -52,12 +52,12 @@ func TestCreateAlreadyExistingNetwork(t *testing.T) {
 	dt.ProvideNetworkInspect(types.NetworkResource{ID: id}, nil)
 
 	networkID, err := c.CreateNetwork(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, id, networkID)
+	require.Nil(t, err)
+	require.Equal(t, id, networkID)
 
 	li := <-dt.LastNetworkInspect()
-	assert.Equal(t, Namespace(namespace), li.Network)
-	assert.Equal(t, types.NetworkInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(namespace), li.Network)
+	require.Equal(t, types.NetworkInspectOptions{}, li.Options)
 
 	select {
 	case <-dt.LastNetworkCreate():
@@ -79,13 +79,13 @@ func TestDeleteNetwork(t *testing.T) {
 
 	dt.ProvideNetworkInspect(types.NetworkResource{ID: id}, nil)
 
-	assert.Nil(t, c.DeleteNetwork(namespace))
+	require.Nil(t, c.DeleteNetwork(namespace))
 
 	li := <-dt.LastNetworkInspect()
-	assert.Equal(t, Namespace(namespace), li.Network)
-	assert.Equal(t, types.NetworkInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(namespace), li.Network)
+	require.Equal(t, types.NetworkInspectOptions{}, li.Options)
 
-	assert.Equal(t, id, (<-dt.LastNetworkRemove()).Network)
+	require.Equal(t, id, (<-dt.LastNetworkRemove()).Network)
 }
 
 func TestDeleteNotExistingNetwork(t *testing.T) {
@@ -100,7 +100,7 @@ func TestDeleteNotExistingNetwork(t *testing.T) {
 
 	dt.ProvideNetworkInspect(types.NetworkResource{}, dockertest.NotFoundErr{})
 
-	assert.Nil(t, c.DeleteNetwork(namespace))
+	require.Nil(t, c.DeleteNetwork(namespace))
 
 	select {
 	case <-dt.LastNetworkRemove():
@@ -123,7 +123,7 @@ func TestDeleteNetworkError(t *testing.T) {
 
 	dt.ProvideNetworkInspect(types.NetworkResource{}, errNetworkDelete)
 
-	assert.NotNil(t, c.DeleteNetwork(namespace))
+	require.NotNil(t, c.DeleteNetwork(namespace))
 }
 
 func TestFindNetwork(t *testing.T) {
@@ -140,12 +140,12 @@ func TestFindNetwork(t *testing.T) {
 	dt.ProvideNetworkInspect(types.NetworkResource{ID: id}, nil)
 
 	network, err := c.FindNetwork(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, id, network.ID)
+	require.Nil(t, err)
+	require.Equal(t, id, network.ID)
 
 	li := <-dt.LastNetworkInspect()
-	assert.Equal(t, Namespace(namespace), li.Network)
-	assert.Equal(t, types.NetworkInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(namespace), li.Network)
+	require.Equal(t, types.NetworkInspectOptions{}, li.Options)
 }
 
 func TestFindNotExistingNetwork(t *testing.T) {
@@ -161,5 +161,5 @@ func TestFindNotExistingNetwork(t *testing.T) {
 	dt.ProvideNetworkInspect(types.NetworkResource{}, dockertest.NotFoundErr{})
 
 	_, err := c.FindNetwork(namespace)
-	assert.Equal(t, dockertest.NotFoundErr{}, err)
+	require.Equal(t, dockertest.NotFoundErr{}, err)
 }

--- a/container/service_integration_test.go
+++ b/container/service_integration_test.go
@@ -5,7 +5,7 @@ package container
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func startTestService(name []string) (string, error) {
@@ -21,97 +21,97 @@ func startTestService(name []string) (string, error) {
 
 func TestIntegrationStartService(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestStartService"}
 	serviceID, err := startTestService(namespace)
 	defer c.StopService(namespace)
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", serviceID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", serviceID)
 }
 
 func TestIntegrationStartService2Times(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestStartService2Times"}
 	startTestService(namespace)
 	defer c.StopService(namespace)
 	serviceID, err := startTestService(namespace)
-	assert.NotNil(t, err)
-	assert.Equal(t, "", serviceID)
+	require.NotNil(t, err)
+	require.Equal(t, "", serviceID)
 }
 
 func TestIntegrationStopService(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestStopService"}
 	startTestService(namespace)
 	err = c.StopService(namespace)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestIntegrationStopNotExistingService(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestStopNotExistingService"}
 	err = c.StopService(namespace)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestIntegrationServiceStatusNeverStarted(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestServiceStatusNeverStarted"}
 	status, err := c.ServiceStatus(namespace)
-	assert.Nil(t, err)
-	assert.NotEqual(t, RUNNING, status)
-	assert.Equal(t, STOPPED, status)
+	require.Nil(t, err)
+	require.NotEqual(t, RUNNING, status)
+	require.Equal(t, STOPPED, status)
 }
 
 func TestIntegrationServiceStatusRunning(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestServiceStatusRunning"}
 	startTestService(namespace)
 	defer c.StopService(namespace)
 	status, err := c.ServiceStatus(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, status, RUNNING)
-	assert.NotEqual(t, status, STOPPED)
+	require.Nil(t, err)
+	require.Equal(t, status, RUNNING)
+	require.NotEqual(t, status, STOPPED)
 }
 
 func TestIntegrationServiceStatusStopped(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestServiceStatusStopped"}
 	startTestService(namespace)
 	c.StopService(namespace)
 	status, err := c.ServiceStatus(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, status, STOPPED)
-	assert.NotEqual(t, status, RUNNING)
+	require.Nil(t, err)
+	require.Equal(t, status, STOPPED)
+	require.NotEqual(t, status, RUNNING)
 }
 
 func TestIntegrationFindServiceNotExisting(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	_, err = c.FindService([]string{"TestFindServiceNotExisting"})
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestIntegrationFindService(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestFindService"}
 	startTestService(namespace)
 	defer c.StopService(namespace)
 	service, err := c.FindService(namespace)
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", service.ID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", service.ID)
 }
 
 func TestIntegrationFindServiceCloseName(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestFindServiceCloseName", "name"}
 	namespace1 := []string{"TestFindServiceCloseName", "name2"}
 	startTestService(namespace)
@@ -119,23 +119,23 @@ func TestIntegrationFindServiceCloseName(t *testing.T) {
 	startTestService(namespace1)
 	defer c.StopService(namespace1)
 	service, err := c.FindService(namespace)
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", service.ID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", service.ID)
 }
 
 func TestIntegrationFindServiceStopped(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestFindServiceStopped"}
 	startTestService(namespace)
 	c.StopService(namespace)
 	_, err = c.FindService(namespace)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestIntegrationListServices(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	c.StartService(ServiceOptions{
 		Image:     "nginx",
 		Namespace: []string{"TestListServices"},
@@ -153,18 +153,18 @@ func TestIntegrationListServices(t *testing.T) {
 	defer c.StopService([]string{"TestListServices"})
 	defer c.StopService([]string{"TestListServiceswithValue2"})
 	services, err := c.ListServices("label_name")
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(services))
-	assert.Equal(t, Namespace([]string{"TestListServices"}), services[0].Spec.Name)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(services))
+	require.Equal(t, Namespace([]string{"TestListServices"}), services[0].Spec.Name)
 }
 
 func TestIntegrationServiceLogs(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestServiceLogs"}
 	startTestService(namespace)
 	defer c.StopService(namespace)
 	reader, err := c.ServiceLogs(namespace)
-	assert.Nil(t, err)
-	assert.NotNil(t, reader)
+	require.Nil(t, err)
+	require.NotNil(t, reader)
 }

--- a/container/service_options_test.go
+++ b/container/service_options_test.go
@@ -3,7 +3,7 @@ package container
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServiceOptionNamespace(t *testing.T) {
@@ -13,9 +13,9 @@ func TestServiceOptionNamespace(t *testing.T) {
 	}
 	expectedNamespace := Namespace(namespace)
 	service := options.toSwarmServiceSpec()
-	assert.Equal(t, expectedNamespace, service.Annotations.Name)
-	assert.Equal(t, expectedNamespace, service.Annotations.Labels["com.docker.stack.namespace"])
-	assert.Equal(t, expectedNamespace, service.TaskTemplate.ContainerSpec.Labels["com.docker.stack.namespace"])
+	require.Equal(t, expectedNamespace, service.Annotations.Name)
+	require.Equal(t, expectedNamespace, service.Annotations.Labels["com.docker.stack.namespace"])
+	require.Equal(t, expectedNamespace, service.TaskTemplate.ContainerSpec.Labels["com.docker.stack.namespace"])
 }
 
 func TestServiceOptionImage(t *testing.T) {
@@ -24,8 +24,8 @@ func TestServiceOptionImage(t *testing.T) {
 		Image: image,
 	}
 	service := options.toSwarmServiceSpec()
-	assert.Equal(t, image, service.Annotations.Labels["com.docker.stack.image"])
-	assert.Equal(t, image, service.TaskTemplate.ContainerSpec.Image)
+	require.Equal(t, image, service.Annotations.Labels["com.docker.stack.image"])
+	require.Equal(t, image, service.TaskTemplate.ContainerSpec.Image)
 }
 
 func TestServiceOptionMergeLabels(t *testing.T) {
@@ -39,10 +39,10 @@ func TestServiceOptionMergeLabels(t *testing.T) {
 		"label4": "bar",
 	}
 	labels := mergeLabels(l1, l2)
-	assert.Equal(t, "foo", labels["label1"])
-	assert.Equal(t, "foo", labels["label2"])
-	assert.Equal(t, "foo", labels["label3"])
-	assert.Equal(t, "bar", labels["label4"])
+	require.Equal(t, "foo", labels["label1"])
+	require.Equal(t, "foo", labels["label2"])
+	require.Equal(t, "foo", labels["label3"])
+	require.Equal(t, "bar", labels["label4"])
 }
 
 func TestServiceOptionLabels(t *testing.T) {
@@ -53,8 +53,8 @@ func TestServiceOptionLabels(t *testing.T) {
 		},
 	}
 	service := options.toSwarmServiceSpec()
-	assert.Equal(t, "foo", service.Annotations.Labels["label1"])
-	assert.Equal(t, "bar", service.Annotations.Labels["label2"])
+	require.Equal(t, "foo", service.Annotations.Labels["label1"])
+	require.Equal(t, "bar", service.Annotations.Labels["label2"])
 }
 
 func TestServiceOptionPorts(t *testing.T) {
@@ -71,11 +71,11 @@ func TestServiceOptionPorts(t *testing.T) {
 		},
 	}
 	ports := options.swarmPorts()
-	assert.Equal(t, 2, len(ports))
-	assert.Equal(t, uint32(50503), ports[0].PublishedPort)
-	assert.Equal(t, uint32(50501), ports[0].TargetPort)
-	assert.Equal(t, uint32(30503), ports[1].PublishedPort)
-	assert.Equal(t, uint32(30501), ports[1].TargetPort)
+	require.Equal(t, 2, len(ports))
+	require.Equal(t, uint32(50503), ports[0].PublishedPort)
+	require.Equal(t, uint32(50501), ports[0].TargetPort)
+	require.Equal(t, uint32(30503), ports[1].PublishedPort)
+	require.Equal(t, uint32(30501), ports[1].TargetPort)
 }
 
 func TestServiceOptionMounts(t *testing.T) {
@@ -88,9 +88,9 @@ func TestServiceOptionMounts(t *testing.T) {
 		},
 	}
 	mounts := options.swarmMounts(true)
-	assert.Equal(t, 1, len(mounts))
-	assert.Equal(t, "source/file", mounts[0].Source)
-	assert.Equal(t, "target/file", mounts[0].Target)
+	require.Equal(t, 1, len(mounts))
+	require.Equal(t, "source/file", mounts[0].Source)
+	require.Equal(t, "target/file", mounts[0].Target)
 }
 
 func TestServiceOptionEnv(t *testing.T) {
@@ -99,9 +99,9 @@ func TestServiceOptionEnv(t *testing.T) {
 	}
 	service := options.toSwarmServiceSpec()
 	env := service.TaskTemplate.ContainerSpec.Env
-	assert.Equal(t, 2, len(env))
-	assert.Equal(t, "env1", env[0])
-	assert.Equal(t, "env2", env[1])
+	require.Equal(t, 2, len(env))
+	require.Equal(t, "env1", env[0])
+	require.Equal(t, "env2", env[1])
 }
 
 func TestServiceOptionNetworks(t *testing.T) {
@@ -109,9 +109,9 @@ func TestServiceOptionNetworks(t *testing.T) {
 		NetworksID: []string{"network1", "network2"},
 	}
 	networks := options.swarmNetworks()
-	assert.Equal(t, 2, len(networks))
-	assert.Equal(t, "network1", networks[0].Target)
-	assert.Equal(t, "network2", networks[1].Target)
+	require.Equal(t, 2, len(networks))
+	require.Equal(t, "network1", networks[0].Target)
+	require.Equal(t, "network2", networks[1].Target)
 }
 
 func contains(list []string, item string) bool {
@@ -128,6 +128,6 @@ func TestMapToEnv(t *testing.T) {
 		"first":  "first_value",
 		"second": "second_value",
 	})
-	assert.True(t, contains(env, "first=first_value"))
-	assert.True(t, contains(env, "second=second_value"))
+	require.True(t, contains(env, "first=first_value"))
+	require.True(t, contains(env, "second=second_value"))
 }

--- a/container/service_test.go
+++ b/container/service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/mesg-foundation/core/container/dockertest"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStartService(t *testing.T) {
@@ -26,12 +26,12 @@ func TestStartService(t *testing.T) {
 	dt.ProvideServiceCreate(types.ServiceCreateResponse{ID: containerID}, nil)
 
 	id, err := c.StartService(options)
-	assert.Nil(t, err)
-	assert.Equal(t, containerID, id)
+	require.Nil(t, err)
+	require.Equal(t, containerID, id)
 
 	ls := <-dt.LastServiceCreate()
-	assert.Equal(t, options.toSwarmServiceSpec(), ls.Service)
-	assert.Equal(t, types.ServiceCreateOptions{}, ls.Options)
+	require.Equal(t, options.toSwarmServiceSpec(), ls.Service)
+	require.Equal(t, types.ServiceCreateOptions{}, ls.Options)
 }
 
 func TestStopService(t *testing.T) {
@@ -49,13 +49,13 @@ func TestStopService(t *testing.T) {
 	dt.ProvideContainerList(containerData, nil)
 	dt.ProvideContainerInspect(containerJSONData, nil)
 
-	assert.Nil(t, c.StopService(namespace))
+	require.Nil(t, c.StopService(namespace))
 
 	li := <-dt.LastServiceInspectWithRaw()
-	assert.Equal(t, Namespace(namespace), li.ServiceID)
-	assert.Equal(t, types.ServiceInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(namespace), li.ServiceID)
+	require.Equal(t, types.ServiceInspectOptions{}, li.Options)
 
-	assert.Equal(t, Namespace(namespace), (<-dt.LastServiceRemove()).ServiceID)
+	require.Equal(t, Namespace(namespace), (<-dt.LastServiceRemove()).ServiceID)
 }
 
 func TestStopNotExistingService(t *testing.T) {
@@ -66,11 +66,11 @@ func TestStopNotExistingService(t *testing.T) {
 
 	dt.ProvideServiceInspectWithRaw(swarm.Service{}, nil, dockertest.NotFoundErr{})
 
-	assert.Nil(t, c.StopService(namespace))
+	require.Nil(t, c.StopService(namespace))
 
 	li := <-dt.LastServiceInspectWithRaw()
-	assert.Equal(t, Namespace(namespace), li.ServiceID)
-	assert.Equal(t, types.ServiceInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(namespace), li.ServiceID)
+	require.Equal(t, types.ServiceInspectOptions{}, li.Options)
 
 	select {
 	case <-dt.LastServiceRemove():
@@ -88,12 +88,12 @@ func TestServiceStatusNeverStarted(t *testing.T) {
 	dt.ProvideServiceInspectWithRaw(swarm.Service{}, nil, dockertest.NotFoundErr{})
 
 	status, err := c.ServiceStatus(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, STOPPED, status)
+	require.Nil(t, err)
+	require.Equal(t, STOPPED, status)
 
 	li := <-dt.LastServiceInspectWithRaw()
-	assert.Equal(t, Namespace(namespace), li.ServiceID)
-	assert.Equal(t, types.ServiceInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(namespace), li.ServiceID)
+	require.Equal(t, types.ServiceInspectOptions{}, li.Options)
 }
 
 func TestServiceStatusRunning(t *testing.T) {
@@ -103,12 +103,12 @@ func TestServiceStatusRunning(t *testing.T) {
 	c, _ := New(ClientOption(dt.Client()))
 
 	status, err := c.ServiceStatus(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, RUNNING, status)
+	require.Nil(t, err)
+	require.Equal(t, RUNNING, status)
 
 	li := <-dt.LastServiceInspectWithRaw()
-	assert.Equal(t, Namespace(namespace), li.ServiceID)
-	assert.Equal(t, types.ServiceInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(namespace), li.ServiceID)
+	require.Equal(t, types.ServiceInspectOptions{}, li.Options)
 }
 
 func TestFindService(t *testing.T) {
@@ -121,12 +121,12 @@ func TestFindService(t *testing.T) {
 	dt.ProvideServiceInspectWithRaw(swarmService, nil, nil)
 
 	service, err := c.FindService(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, swarmService.ID, service.ID)
+	require.Nil(t, err)
+	require.Equal(t, swarmService.ID, service.ID)
 
 	li := <-dt.LastServiceInspectWithRaw()
-	assert.Equal(t, Namespace(namespace), li.ServiceID)
-	assert.Equal(t, types.ServiceInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(namespace), li.ServiceID)
+	require.Equal(t, types.ServiceInspectOptions{}, li.Options)
 }
 
 func TestFindServiceNotExisting(t *testing.T) {
@@ -138,11 +138,11 @@ func TestFindServiceNotExisting(t *testing.T) {
 	dt.ProvideServiceInspectWithRaw(swarm.Service{}, nil, dockertest.NotFoundErr{})
 
 	_, err := c.FindService(namespace)
-	assert.Equal(t, dockertest.NotFoundErr{}, err)
+	require.Equal(t, dockertest.NotFoundErr{}, err)
 
 	li := <-dt.LastServiceInspectWithRaw()
-	assert.Equal(t, Namespace(namespace), li.ServiceID)
-	assert.Equal(t, types.ServiceInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(namespace), li.ServiceID)
+	require.Equal(t, types.ServiceInspectOptions{}, li.Options)
 }
 
 func TestListServices(t *testing.T) {
@@ -160,12 +160,12 @@ func TestListServices(t *testing.T) {
 	dt.ProvideServiceList(swarmServices, nil)
 
 	services, err := c.ListServices(label)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(services))
-	assert.Equal(t, Namespace(namespace), services[0].Spec.Name)
-	assert.Equal(t, Namespace(namespace1), services[1].Spec.Name)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(services))
+	require.Equal(t, Namespace(namespace), services[0].Spec.Name)
+	require.Equal(t, Namespace(namespace1), services[1].Spec.Name)
 
-	assert.Equal(t, types.ServiceListOptions{
+	require.Equal(t, types.ServiceListOptions{
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: label,
@@ -183,16 +183,16 @@ func TestServiceLogs(t *testing.T) {
 	dt.ProvideServiceLogs(ioutil.NopCloser(bytes.NewReader(data)), nil)
 
 	reader, err := c.ServiceLogs(namespace)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	defer reader.Close()
 
 	bytes, err := ioutil.ReadAll(reader)
-	assert.Nil(t, err)
-	assert.Equal(t, data, bytes)
+	require.Nil(t, err)
+	require.Equal(t, data, bytes)
 
 	ll := <-dt.LastServiceLogs()
-	assert.Equal(t, Namespace(namespace), ll.ServiceID)
-	assert.Equal(t, types.ContainerLogsOptions{
+	require.Equal(t, Namespace(namespace), ll.ServiceID)
+	require.Equal(t, types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Timestamps: false,

--- a/container/shared_network_integration_test.go
+++ b/container/shared_network_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	docker "github.com/docker/docker/client"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func removeSharedNetworkIfExist(c *Container) error {
@@ -22,25 +22,25 @@ func removeSharedNetworkIfExist(c *Container) error {
 
 func TestIntegrationCreateSharedNetworkIfNeeded(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	err = removeSharedNetworkIfExist(c)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	err = c.createSharedNetworkIfNeeded()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestIntegrationSharedNetwork(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	network, err := c.sharedNetwork()
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", network.ID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", network.ID)
 }
 
 func TestIntegrationSharedNetworkID(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	networkID, err := c.SharedNetworkID()
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", networkID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", networkID)
 }

--- a/container/shared_network_test.go
+++ b/container/shared_network_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/mesg-foundation/core/container/dockertest"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSharedNetwork(t *testing.T) {
@@ -21,12 +21,12 @@ func TestSharedNetwork(t *testing.T) {
 	dt.ProvideNetworkInspect(types.NetworkResource{ID: id}, nil)
 
 	network, err := c.sharedNetwork()
-	assert.Nil(t, err)
-	assert.Equal(t, id, network.ID)
+	require.Nil(t, err)
+	require.Equal(t, id, network.ID)
 
 	li := <-dt.LastNetworkInspect()
-	assert.Equal(t, Namespace(sharedNetworkNamespace), li.Network)
-	assert.Equal(t, types.NetworkInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(sharedNetworkNamespace), li.Network)
+	require.Equal(t, types.NetworkInspectOptions{}, li.Options)
 }
 
 func TestCreateSharedNetworkIfNeeded(t *testing.T) {
@@ -39,11 +39,11 @@ func TestCreateSharedNetworkIfNeeded(t *testing.T) {
 
 	dt.ProvideNetworkInspect(types.NetworkResource{}, nil)
 
-	assert.Nil(t, c.createSharedNetworkIfNeeded())
+	require.Nil(t, c.createSharedNetworkIfNeeded())
 
 	lc := <-dt.LastNetworkCreate()
-	assert.Equal(t, Namespace(sharedNetworkNamespace), lc.Name)
-	assert.Equal(t, types.NetworkCreate{
+	require.Equal(t, Namespace(sharedNetworkNamespace), lc.Name)
+	require.Equal(t, types.NetworkCreate{
 		CheckDuplicate: true,
 		Driver:         "overlay",
 		Labels: map[string]string{
@@ -64,7 +64,7 @@ func TestCreateSharedNetworkIfNeededExists(t *testing.T) {
 
 	dt.ProvideNetworkInspect(types.NetworkResource{ID: id}, nil)
 
-	assert.Nil(t, c.createSharedNetworkIfNeeded())
+	require.Nil(t, c.createSharedNetworkIfNeeded())
 
 	select {
 	case <-dt.LastNetworkCreate():
@@ -85,10 +85,10 @@ func TestSharedNetworkID(t *testing.T) {
 	dt.ProvideNetworkInspect(types.NetworkResource{ID: id}, nil)
 
 	network, err := c.SharedNetworkID()
-	assert.Nil(t, err)
-	assert.Equal(t, network, id)
+	require.Nil(t, err)
+	require.Equal(t, network, id)
 
 	li := <-dt.LastNetworkInspect()
-	assert.Equal(t, Namespace(sharedNetworkNamespace), li.Network)
-	assert.Equal(t, types.NetworkInspectOptions{}, li.Options)
+	require.Equal(t, Namespace(sharedNetworkNamespace), li.Network)
+	require.Equal(t, types.NetworkInspectOptions{}, li.Options)
 }

--- a/container/task_integration_test.go
+++ b/container/task_integration_test.go
@@ -6,24 +6,24 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationListTasks(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestListTasks"}
 	startTestService(namespace)
 	defer c.StopService(namespace)
 	tasks, err := c.ListTasks(namespace)
-	assert.Nil(t, err)
-	assert.NotNil(t, tasks)
-	assert.Equal(t, 1, len(tasks))
+	require.Nil(t, err)
+	require.NotNil(t, tasks)
+	require.Equal(t, 1, len(tasks))
 }
 
 func TestIntegrationTasksError(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestTasksError"}
 	c.StartService(ServiceOptions{
 		Image:     "fiifioewifewiewfifewijopwjeokpfeo",
@@ -38,8 +38,8 @@ func TestIntegrationTasksError(t *testing.T) {
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	assert.Nil(t, err)
-	assert.NotNil(t, errors)
-	assert.True(t, len(errors) > 0)
-	assert.Equal(t, "No such image: fiifioewifewiewfifewijopwjeokpfeo:latest", errors[0])
+	require.Nil(t, err)
+	require.NotNil(t, errors)
+	require.True(t, len(errors) > 0)
+	require.Equal(t, "No such image: fiifioewifewiewfifewijopwjeokpfeo:latest", errors[0])
 }

--- a/container/task_test.go
+++ b/container/task_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/mesg-foundation/core/container/dockertest"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListTasks(t *testing.T) {
@@ -24,11 +24,11 @@ func TestListTasks(t *testing.T) {
 	dt.ProvideTaskList(tasks, nil)
 
 	tasks1, err := c.ListTasks(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, tasks, tasks1)
-	assert.Equal(t, len(tasks), len(tasks1))
+	require.Nil(t, err)
+	require.Equal(t, tasks, tasks1)
+	require.Equal(t, len(tasks), len(tasks1))
 
-	assert.Equal(t, types.TaskListOptions{
+	require.Equal(t, types.TaskListOptions{
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: "com.docker.stack.namespace=" + Namespace(namespace),
@@ -47,7 +47,7 @@ func TestListTasksError(t *testing.T) {
 	dt.ProvideTaskList(nil, errTaskList)
 
 	_, err := c.ListTasks(namespace)
-	assert.Equal(t, errTaskList, err)
+	require.Equal(t, errTaskList, err)
 }
 
 func TestTasksError(t *testing.T) {
@@ -69,8 +69,8 @@ func TestTasksError(t *testing.T) {
 	dt.ProvideTaskList(tasks, nil)
 
 	errors, err := c.TasksError(namespace)
-	assert.Nil(t, err)
-	assert.Equal(t, len(tasks), len(errors))
-	assert.Equal(t, tasks[0].Status.Err, errors[0])
-	assert.Equal(t, tasks[1].Status.Err, errors[1])
+	require.Nil(t, err)
+	require.Equal(t, len(tasks), len(errors))
+	require.Equal(t, tasks[0].Status.Err, errors[0])
+	require.Equal(t, tasks[1].Status.Err, errors[1])
 }

--- a/container/wait_integration_test.go
+++ b/container/wait_integration_test.go
@@ -5,33 +5,33 @@ package container
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationWaitForStatusRunning(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestWaitForStatusRunning"}
 	startTestService(namespace)
 	defer c.StopService(namespace)
 	err = c.waitForStatus(namespace, RUNNING)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestIntegrationWaitForStatusStopped(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestWaitForStatusStopped"}
 	startTestService(namespace)
 	c.waitForStatus(namespace, RUNNING)
 	c.StopService(namespace)
 	err = c.waitForStatus(namespace, STOPPED)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestIntegrationWaitForStatusTaskError(t *testing.T) {
 	c, err := New()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	namespace := []string{"TestWaitForStatusTaskError"}
 	c.StartService(ServiceOptions{
 		Image:     "awgdaywudaywudwa",
@@ -39,6 +39,6 @@ func TestIntegrationWaitForStatusTaskError(t *testing.T) {
 	})
 	defer c.StopService(namespace)
 	err = c.waitForStatus(namespace, RUNNING)
-	assert.NotNil(t, err)
-	assert.Equal(t, "No such image: awgdaywudaywudwa:latest", err.Error())
+	require.NotNil(t, err)
+	require.Equal(t, "No such image: awgdaywudaywudwa:latest", err.Error())
 }

--- a/container/wait_test.go
+++ b/container/wait_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/mesg-foundation/core/container/dockertest"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWaitForStatusRunning(t *testing.T) {
@@ -28,7 +28,7 @@ func TestWaitForStatusRunning(t *testing.T) {
 	dt.ProvideContainerList(containerData, nil)
 	dt.ProvideContainerInspect(containerJSONData, nil)
 
-	assert.Nil(t, c.waitForStatus(namespace, RUNNING))
+	require.Nil(t, c.waitForStatus(namespace, RUNNING))
 }
 
 func TestWaitForStatusStopped(t *testing.T) {
@@ -50,7 +50,7 @@ func TestWaitForStatusStopped(t *testing.T) {
 	dt.ProvideContainerList(containerData, nil)
 	dt.ProvideContainerInspect(containerJSONData, nil)
 
-	assert.Nil(t, c.waitForStatus(namespace, STOPPED))
+	require.Nil(t, c.waitForStatus(namespace, STOPPED))
 }
 
 func TestWaitForStatusTaskError(t *testing.T) {
@@ -71,7 +71,7 @@ func TestWaitForStatusTaskError(t *testing.T) {
 
 	dt.ProvideTaskList(tasks, nil)
 
-	assert.Equal(t, "1-err, 2-err", c.waitForStatus(namespace, RUNNING).Error())
+	require.Equal(t, "1-err, 2-err", c.waitForStatus(namespace, RUNNING).Error())
 
 	select {
 	case <-dt.LastContainerList():

--- a/daemon/logs_test.go
+++ b/daemon/logs_test.go
@@ -3,12 +3,12 @@ package daemon
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogs(t *testing.T) {
 	startForTest()
 	reader, err := Logs()
-	assert.Nil(t, err)
-	assert.NotNil(t, reader)
+	require.Nil(t, err)
+	require.NotNil(t, reader)
 }

--- a/daemon/start_test.go
+++ b/daemon/start_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mesg-foundation/core/config"
 	"github.com/mesg-foundation/core/container"
 	"github.com/spf13/viper"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // startForTest starts a dummy MESG Core service
@@ -37,8 +37,8 @@ func startForTest() {
 // func TestStart(t *testing.T) {
 // 	<-testForceAndWaitForFullStop()
 // 	service, err := Start()
-// 	assert.Nil(t, err)
-// 	assert.NotNil(t, service)
+// 	require.Nil(t, err)
+// 	require.NotNil(t, service)
 // }
 
 func contains(list []string, item string) bool {
@@ -52,18 +52,18 @@ func contains(list []string, item string) bool {
 
 func TestStartConfig(t *testing.T) {
 	spec, err := serviceSpec()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	// Make sure that the config directory is passed in parameter to write on the same folder
-	assert.True(t, contains(spec.Env, "MESG_MESG_PATH=/mesg"))
-	assert.True(t, contains(spec.Env, "MESG_API_SERVICE_SOCKETPATH="+filepath.Join(viper.GetString(config.MESGPath), "server.sock")))
-	assert.True(t, contains(spec.Env, "MESG_SERVICE_PATH_HOST="+filepath.Join(viper.GetString(config.MESGPath), "services")))
+	require.True(t, contains(spec.Env, "MESG_MESG_PATH=/mesg"))
+	require.True(t, contains(spec.Env, "MESG_API_SERVICE_SOCKETPATH="+filepath.Join(viper.GetString(config.MESGPath), "server.sock")))
+	require.True(t, contains(spec.Env, "MESG_SERVICE_PATH_HOST="+filepath.Join(viper.GetString(config.MESGPath), "services")))
 	// Ensure that the port is shared
-	assert.Equal(t, spec.Ports[0].Published, uint32(50052))
-	assert.Equal(t, spec.Ports[0].Target, uint32(50052))
+	require.Equal(t, spec.Ports[0].Published, uint32(50052))
+	require.Equal(t, spec.Ports[0].Target, uint32(50052))
 	// Ensure that the docker socket is shared in the core
-	assert.Equal(t, spec.Mounts[0].Source, dockerSocket)
-	assert.Equal(t, spec.Mounts[0].Target, dockerSocket)
+	require.Equal(t, spec.Mounts[0].Source, dockerSocket)
+	require.Equal(t, spec.Mounts[0].Target, dockerSocket)
 	// Ensure that the host users folder is sync with the core
-	assert.Equal(t, spec.Mounts[1].Source, viper.GetString(config.MESGPath))
-	assert.Equal(t, spec.Mounts[1].Target, "/mesg")
+	require.Equal(t, spec.Mounts[1].Source, viper.GetString(config.MESGPath))
+	require.Equal(t, spec.Mounts[1].Target, "/mesg")
 }

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/mesg-foundation/core/container"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testForceAndWaitForFullStop() chan error {
@@ -43,13 +43,13 @@ func testForceAndWaitForFullStop() chan error {
 func TestIsNotRunning(t *testing.T) {
 	<-testForceAndWaitForFullStop()
 	status, err := Status()
-	assert.Nil(t, err)
-	assert.Equal(t, container.STOPPED, status)
+	require.Nil(t, err)
+	require.Equal(t, container.STOPPED, status)
 }
 
 func TestIsRunning(t *testing.T) {
 	startForTest()
 	status, err := Status()
-	assert.Nil(t, err)
-	assert.Equal(t, container.RUNNING, status)
+	require.Nil(t, err)
+	require.Equal(t, container.RUNNING, status)
 }

--- a/daemon/stop_test.go
+++ b/daemon/stop_test.go
@@ -3,11 +3,11 @@ package daemon
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStop(t *testing.T) {
 	startForTest()
 	err := Stop()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }

--- a/database/services/all_test.go
+++ b/database/services/all_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAll(t *testing.T) {
@@ -18,6 +18,6 @@ func TestAll(t *testing.T) {
 			break
 		}
 	}
-	assert.Nil(t, err)
-	assert.True(t, founded)
+	require.Nil(t, err)
+	require.True(t, founded)
 }

--- a/database/services/db_test.go
+++ b/database/services/db_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDb(t *testing.T) {
 	db, err := open()
 	defer close()
-	assert.Nil(t, err)
-	assert.NotNil(t, db)
+	require.Nil(t, err)
+	require.NotNil(t, db)
 }
 
 // Test to stress the database with concurrency access
@@ -28,8 +28,8 @@ func TestConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			s, err := Get(hash)
-			assert.Nil(t, err)
-			assert.Equal(t, s.Name, service.Name)
+			require.Nil(t, err)
+			require.Equal(t, s.Name, service.Name)
 			wg.Done()
 		}()
 	}

--- a/database/services/delete_test.go
+++ b/database/services/delete_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete(t *testing.T) {
@@ -12,5 +12,5 @@ func TestDelete(t *testing.T) {
 		Name: "TestDelete",
 	})
 	err := Delete(hash)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }

--- a/database/services/get_test.go
+++ b/database/services/get_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGet(t *testing.T) {
@@ -13,13 +13,13 @@ func TestGet(t *testing.T) {
 	})
 	defer Delete(hash)
 	service, err := Get(hash)
-	assert.Nil(t, err)
-	assert.Equal(t, service.Name, "TestGet")
+	require.Nil(t, err)
+	require.Equal(t, service.Name, "TestGet")
 }
 
 func TestGetMissing(t *testing.T) {
 	emptyService := service.Service{}
 	service, err := Get("hash_that_doesnt_exists")
-	assert.Equal(t, err, NotFound{Hash: "hash_that_doesnt_exists"})
-	assert.Equal(t, service, emptyService)
+	require.Equal(t, err, NotFound{Hash: "hash_that_doesnt_exists"})
+	require.Equal(t, service, emptyService)
 }

--- a/database/services/save_test.go
+++ b/database/services/save_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSaveReturningHash(t *testing.T) {
@@ -14,8 +14,8 @@ func TestSaveReturningHash(t *testing.T) {
 	calculatedHash := service.Hash()
 	hash, err := Save(service)
 	defer Delete(hash)
-	assert.Nil(t, err)
-	assert.Equal(t, hash, calculatedHash)
+	require.Nil(t, err)
+	require.Equal(t, hash, calculatedHash)
 }
 
 func TestSaveAndPresentInDB(t *testing.T) {
@@ -24,5 +24,5 @@ func TestSaveAndPresentInDB(t *testing.T) {
 	})
 	defer Delete(hash)
 	service, _ := Get(hash)
-	assert.Equal(t, service.Name, "TestSaveAndPresentInDB")
+	require.Equal(t, service.Name, "TestSaveAndPresentInDB")
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreate(t *testing.T) {
@@ -16,11 +16,11 @@ func TestCreate(t *testing.T) {
 	}
 	var data map[string]interface{}
 	exec, err := Create(&s, "test", data)
-	assert.Nil(t, err)
-	assert.Equal(t, &s, exec.Service)
-	assert.Equal(t, data, exec.Data)
-	assert.Equal(t, "test", exec.Key)
-	assert.NotNil(t, exec.CreatedAt)
+	require.Nil(t, err)
+	require.Equal(t, &s, exec.Service)
+	require.Equal(t, data, exec.Data)
+	require.Equal(t, "test", exec.Key)
+	require.NotNil(t, exec.CreatedAt)
 }
 
 func TestCreateNotPresentEvent(t *testing.T) {
@@ -32,9 +32,9 @@ func TestCreateNotPresentEvent(t *testing.T) {
 	}
 	var data map[string]interface{}
 	_, err := Create(&s, "testinvalid", data)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	_, notFound := err.(*service.EventNotFoundError)
-	assert.True(t, notFound)
+	require.True(t, notFound)
 }
 
 func TestCreateInvalidData(t *testing.T) {
@@ -50,7 +50,7 @@ func TestCreateInvalidData(t *testing.T) {
 	}
 	var data map[string]interface{}
 	_, err := Create(&s, "test", data)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	_, invalid := err.(*service.InvalidEventDataError)
-	assert.True(t, invalid)
+	require.True(t, invalid)
 }

--- a/execution/complete_test.go
+++ b/execution/complete_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestComplete(t *testing.T) {
@@ -23,10 +23,10 @@ func TestComplete(t *testing.T) {
 	execution.Execute()
 	var outputs map[string]interface{}
 	err := execution.Complete("output", outputs)
-	assert.Nil(t, err)
-	assert.Equal(t, execution.Output, "output")
-	assert.Equal(t, execution.OutputData, outputs)
-	assert.True(t, execution.ExecutionDuration > 0)
+	require.Nil(t, err)
+	require.Equal(t, execution.Output, "output")
+	require.Equal(t, execution.OutputData, outputs)
+	require.True(t, execution.ExecutionDuration > 0)
 }
 
 func TestCompleteNotFound(t *testing.T) {
@@ -41,10 +41,10 @@ func TestCompleteNotFound(t *testing.T) {
 	execution.Execute()
 	var outputs map[string]interface{}
 	err := execution.Complete("output", outputs)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	x, missingOutputError := err.(*service.OutputNotFoundError)
-	assert.True(t, missingOutputError)
-	assert.Equal(t, "output", x.OutputKey)
+	require.True(t, missingOutputError)
+	require.Equal(t, "output", x.OutputKey)
 }
 
 func TestCompleteInvalidOutputs(t *testing.T) {
@@ -67,10 +67,10 @@ func TestCompleteInvalidOutputs(t *testing.T) {
 	execution.Execute()
 	var outputs map[string]interface{}
 	err := execution.Complete("output", outputs)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	x, invalidOutputError := err.(*service.InvalidOutputDataError)
-	assert.True(t, invalidOutputError)
-	assert.Equal(t, "output", x.Key)
+	require.True(t, invalidOutputError)
+	require.Equal(t, "output", x.Key)
 }
 
 func TestCompleteNotProcessed(t *testing.T) {
@@ -88,8 +88,8 @@ func TestCompleteNotProcessed(t *testing.T) {
 	execution, _ := Create(&s, "test", inputs)
 	var outputs map[string]interface{}
 	err := execution.Complete("output", outputs)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	x, notInQueueError := err.(*NotInQueueError)
-	assert.True(t, notInQueueError)
-	assert.Equal(t, "inProgress", x.Queue)
+	require.True(t, notInQueueError)
+	require.Equal(t, "inProgress", x.Queue)
 }

--- a/execution/create_test.go
+++ b/execution/create_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mesg-foundation/core/service"
 	"github.com/mesg-foundation/core/utils/hash"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateID(t *testing.T) {
@@ -21,8 +21,8 @@ func TestGenerateID(t *testing.T) {
 		Inputs:    i,
 	}
 	id, err := generateID(&execution)
-	assert.Nil(t, err)
-	assert.Equal(t, id, hash.Calculate([]string{
+	require.Nil(t, err)
+	require.Equal(t, id, hash.Calculate([]string{
 		execution.CreatedAt.UTC().String(),
 		execution.Service.Name,
 		execution.Task,
@@ -39,11 +39,11 @@ func TestCreate(t *testing.T) {
 	}
 	var inputs map[string]interface{}
 	exec, err := Create(&s, "test", inputs)
-	assert.Nil(t, err)
-	assert.Equal(t, exec.Service, &s)
-	assert.Equal(t, exec.Inputs, inputs)
-	assert.Equal(t, exec.Task, "test")
-	assert.Equal(t, pendingExecutions[exec.ID], exec)
+	require.Nil(t, err)
+	require.Equal(t, exec.Service, &s)
+	require.Equal(t, exec.Inputs, inputs)
+	require.Equal(t, exec.Task, "test")
+	require.Equal(t, pendingExecutions[exec.ID], exec)
 }
 
 func TestCreateInvalidTask(t *testing.T) {
@@ -55,9 +55,9 @@ func TestCreateInvalidTask(t *testing.T) {
 	}
 	var inputs map[string]interface{}
 	_, err := Create(&s, "testinvalid", inputs)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	_, notFound := err.(*service.TaskNotFoundError)
-	assert.True(t, notFound)
+	require.True(t, notFound)
 }
 
 func TestCreateInvalidInputs(t *testing.T) {
@@ -75,7 +75,7 @@ func TestCreateInvalidInputs(t *testing.T) {
 	}
 	var inputs map[string]interface{}
 	_, err := Create(&s, "test", inputs)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	_, invalid := err.(*service.InvalidTaskInputError)
-	assert.True(t, invalid)
+	require.True(t, invalid)
 }

--- a/execution/error_test.go
+++ b/execution/error_test.go
@@ -3,10 +3,10 @@ package execution
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNotInQueueError(t *testing.T) {
 	e := NotInQueueError{"test", "queueName"}
-	assert.Contains(t, "Execution 'test' not found in queue 'queueName'", e.Error())
+	require.Contains(t, "Execution 'test' not found in queue 'queueName'", e.Error())
 }

--- a/execution/error_test.go
+++ b/execution/error_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestNotInQueueError(t *testing.T) {
 	e := NotInQueueError{"test", "queueName"}
-	require.Contains(t, "Execution 'test' not found in queue 'queueName'", e.Error())
+	require.Contains(t, e.Error(), "Execution 'test' not found in queue 'queueName'")
 }

--- a/execution/execute_test.go
+++ b/execution/execute_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExecute(t *testing.T) {
@@ -17,7 +17,7 @@ func TestExecute(t *testing.T) {
 	var inputs map[string]interface{}
 	execution, _ := Create(&s, "test", inputs)
 	err := execution.Execute()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestExecuteNotPending(t *testing.T) {
@@ -25,5 +25,5 @@ func TestExecuteNotPending(t *testing.T) {
 		ID: "TestExecuteNotPending",
 	}
 	err := execution.Execute()
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }

--- a/execution/state_test.go
+++ b/execution/state_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/service"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMoveFromPendingToInProgress(t *testing.T) {
@@ -17,16 +17,16 @@ func TestMoveFromPendingToInProgress(t *testing.T) {
 	var inputs map[string]interface{}
 	exec, _ := Create(&s, "test", inputs)
 	err := exec.moveFromPendingToInProgress()
-	assert.Equal(t, inProgressExecutions[exec.ID], exec)
-	assert.Nil(t, pendingExecutions[exec.ID])
-	assert.Nil(t, err)
+	require.Equal(t, inProgressExecutions[exec.ID], exec)
+	require.Nil(t, pendingExecutions[exec.ID])
+	require.Nil(t, err)
 }
 
 func TestMoveFromPendingToInProgressNonExistingTask(t *testing.T) {
 	exec := Execution{ID: "test"}
 	err := exec.moveFromPendingToInProgress()
-	assert.NotNil(t, err)
-	assert.Nil(t, pendingExecutions[exec.ID])
+	require.NotNil(t, err)
+	require.Nil(t, pendingExecutions[exec.ID])
 }
 
 func TestMoveFromInProgressToCompleted(t *testing.T) {
@@ -40,9 +40,9 @@ func TestMoveFromInProgressToCompleted(t *testing.T) {
 	exec, _ := Create(&s, "test", inputs)
 	exec.moveFromPendingToInProgress()
 	err := exec.moveFromInProgressToProcessed()
-	assert.Equal(t, processedExecutions[exec.ID], exec)
-	assert.Nil(t, inProgressExecutions[exec.ID])
-	assert.Nil(t, err)
+	require.Equal(t, processedExecutions[exec.ID], exec)
+	require.Nil(t, inProgressExecutions[exec.ID])
+	require.Nil(t, err)
 }
 
 func TestMoveFromInProgressToCompletedNonExistingTask(t *testing.T) {
@@ -55,13 +55,13 @@ func TestMoveFromInProgressToCompletedNonExistingTask(t *testing.T) {
 	var inputs map[string]interface{}
 	exec, _ := Create(&s, "test", inputs)
 	err := exec.moveFromInProgressToProcessed()
-	assert.NotNil(t, err)
-	assert.Nil(t, inProgressExecutions[exec.ID])
+	require.NotNil(t, err)
+	require.Nil(t, inProgressExecutions[exec.ID])
 }
 
 func TestInProgress(t *testing.T) {
 	inProgressExecutions["foo"] = &Execution{ID: "TestInProgress"}
-	assert.NotNil(t, InProgress("foo"))
-	assert.Equal(t, "TestInProgress", InProgress("foo").ID)
-	assert.Nil(t, InProgress("bar"))
+	require.NotNil(t, InProgress("foo"))
+	require.Equal(t, "TestInProgress", InProgress("foo").ID)
+	require.Nil(t, InProgress("bar"))
 }

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -36,14 +36,14 @@ func TestSubscribe(t *testing.T) {
 	key := "TestSubscribe"
 	res := Subscribe(key)
 	require.NotNil(t, res)
-	require.Equal(t, len(listeners[key]), 1)
+	require.Len(t, listeners[key], 1)
 }
 
 func TestSubscribeMultipleTimes(t *testing.T) {
 	key := "TestSubscribeMultipleTimes"
 	Subscribe(key)
 	Subscribe(key)
-	require.Equal(t, len(listeners[key]), 2)
+	require.Len(t, listeners[key], 2)
 }
 
 func TestUnsubscribe(t *testing.T) {
@@ -51,9 +51,7 @@ func TestUnsubscribe(t *testing.T) {
 	channel := Subscribe(key)
 	channel1 := Subscribe(key)
 	Unsubscribe(key, channel)
-	assert.Equal(t, len(listeners[key]), 1)
-	assert.NotNil(t, listeners[key])
+	require.Len(t, listeners[key], 1)
 	Unsubscribe(key, channel1)
-	assert.Equal(t, len(listeners[key]), 0)
-	assert.Nil(t, listeners[key])
+	require.Nil(t, listeners[key])
 }

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -3,7 +3,7 @@ package pubsub
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type messageStructTest struct {
@@ -17,7 +17,7 @@ func TestPublish(t *testing.T) {
 	res := Subscribe(key)
 	go Publish(key, data)
 	x := <-res
-	assert.Equal(t, x, data)
+	require.Equal(t, x, data)
 }
 
 func TestPublishMultipleListeners(t *testing.T) {
@@ -28,22 +28,22 @@ func TestPublishMultipleListeners(t *testing.T) {
 	go Publish(key, data)
 	x := <-res1
 	y := <-res2
-	assert.Equal(t, x, data)
-	assert.Equal(t, y, data)
+	require.Equal(t, x, data)
+	require.Equal(t, y, data)
 }
 
 func TestSubscribe(t *testing.T) {
 	key := "TestSubscribe"
 	res := Subscribe(key)
-	assert.NotNil(t, res)
-	assert.Equal(t, len(listeners[key]), 1)
+	require.NotNil(t, res)
+	require.Equal(t, len(listeners[key]), 1)
 }
 
 func TestSubscribeMultipleTimes(t *testing.T) {
 	key := "TestSubscribeMultipleTimes"
 	Subscribe(key)
 	Subscribe(key)
-	assert.Equal(t, len(listeners[key]), 2)
+	require.Equal(t, len(listeners[key]), 2)
 }
 
 func TestUnsubscribe(t *testing.T) {

--- a/service/cast_test.go
+++ b/service/cast_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServiceCast(t *testing.T) {
@@ -69,16 +69,16 @@ func TestServiceCast(t *testing.T) {
 	for _, tt := range tests {
 		got, err := tt.service.Cast("test", tt.data)
 		if tt.expectErr {
-			assert.NotNil(t, err)
+			require.NotNil(t, err)
 		} else {
-			assert.Equal(t, len(tt.expected), len(got), "maps len are not equal")
-			assert.Equal(t, tt.expected, got, "maps are not equal")
+			require.Equal(t, len(tt.expected), len(got), "maps len are not equal")
+			require.Equal(t, tt.expected, got, "maps are not equal")
 		}
 	}
 
 	// test if non-existing key returns error
 	_, err := tests[0].service.Cast("_", nil)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 // creates test service with given inputs name and type under "test" task key.

--- a/service/dependency_test.go
+++ b/service/dependency_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDependenciesFromService(t *testing.T) {
@@ -19,8 +19,8 @@ func TestDependenciesFromService(t *testing.T) {
 		},
 	}
 	deps := service.DependenciesFromService()
-	assert.Equal(t, 2, len(deps))
-	assert.Equal(t, "testa", deps[0].Name)
-	assert.Equal(t, "TestPartiallyRunningService", deps[0].Service.Name)
-	assert.Equal(t, "testb", deps[1].Name)
+	require.Equal(t, 2, len(deps))
+	require.Equal(t, "testa", deps[0].Name)
+	require.Equal(t, "TestPartiallyRunningService", deps[0].Service.Name)
+	require.Equal(t, "testb", deps[1].Name)
 }

--- a/service/error_test.go
+++ b/service/error_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type parameterTests []*parameterTest
@@ -35,7 +35,7 @@ func (tests parameterTests) parameterTestsToMapData() map[string]interface{} {
 
 func (tests parameterTests) assert(t *testing.T, err string) {
 	for _, test := range tests {
-		assert.Contains(t, "Value of '"+test.Key+"' is "+test.Error, err)
+		require.Contains(t, "Value of '"+test.Key+"' is "+test.Error, err)
 	}
 }
 
@@ -45,7 +45,7 @@ func TestEventNotFoundError(t *testing.T) {
 		Service:  &Service{Name: "TestEventNotFoundError"},
 		EventKey: "TestEventNotFoundErrorEventKey",
 	}
-	assert.Equal(t, "Event 'TestEventNotFoundErrorEventKey' not found in service 'TestEventNotFoundError'", err.Error())
+	require.Equal(t, "Event 'TestEventNotFoundErrorEventKey' not found in service 'TestEventNotFoundError'", err.Error())
 }
 
 // Test InvalidEventDataError
@@ -65,7 +65,7 @@ func TestInvalidEventDataError(t *testing.T) {
 		Key:  "TestInvalidEventDataErrorEventKey",
 		Data: tests.parameterTestsToMapData(),
 	}
-	assert.Contains(t, "Data of event 'TestInvalidEventDataErrorEventKey' is invalid", err.Error())
+	require.Contains(t, "Data of event 'TestInvalidEventDataErrorEventKey' is invalid", err.Error())
 	tests.assert(t, err.Error())
 }
 
@@ -75,7 +75,7 @@ func TestTaskNotFoundError(t *testing.T) {
 		Service: &Service{Name: "TestTaskNotFoundError"},
 		TaskKey: "TestTaskNotFoundErrorEventKey",
 	}
-	assert.Equal(t, "Task 'TestTaskNotFoundErrorEventKey' not found in service 'TestTaskNotFoundError'", err.Error())
+	require.Equal(t, "Task 'TestTaskNotFoundErrorEventKey' not found in service 'TestTaskNotFoundError'", err.Error())
 }
 
 // Test InvalidTaskInputError
@@ -95,7 +95,7 @@ func TestInvalidTaskInputError(t *testing.T) {
 		Key:    "TestInvalidTaskInputErrorEventKey",
 		Inputs: tests.parameterTestsToMapData(),
 	}
-	assert.Contains(t, "Inputs of task 'TestInvalidTaskInputErrorEventKey' are invalid", err.Error())
+	require.Contains(t, "Inputs of task 'TestInvalidTaskInputErrorEventKey' are invalid", err.Error())
 	tests.assert(t, err.Error())
 }
 
@@ -105,7 +105,7 @@ func TestOutputNotFoundError(t *testing.T) {
 		Service:   &Service{Name: "TestOutputNotFoundError"},
 		OutputKey: "TestOutputNotFoundErrorEventKey",
 	}
-	assert.Equal(t, "Output 'TestOutputNotFoundErrorEventKey' not found in service 'TestOutputNotFoundError'", err.Error())
+	require.Equal(t, "Output 'TestOutputNotFoundErrorEventKey' not found in service 'TestOutputNotFoundError'", err.Error())
 }
 
 // Test InvalidOutputDataError
@@ -125,6 +125,6 @@ func TestInvalidOutputDataError(t *testing.T) {
 		Key:  "TestInvalidOutputDataErrorEventKey",
 		Data: tests.parameterTestsToMapData(),
 	}
-	assert.Contains(t, "Outputs of task 'TestInvalidOutputDataErrorEventKey' are invalid", err.Error())
+	require.Contains(t, "Outputs of task 'TestInvalidOutputDataErrorEventKey' are invalid", err.Error())
 	tests.assert(t, err.Error())
 }

--- a/service/error_test.go
+++ b/service/error_test.go
@@ -35,7 +35,7 @@ func (tests parameterTests) parameterTestsToMapData() map[string]interface{} {
 
 func (tests parameterTests) assert(t *testing.T, err string) {
 	for _, test := range tests {
-		require.Contains(t, "Value of '"+test.Key+"' is "+test.Error, err)
+		require.Contains(t, err, "Value of '"+test.Key+"' is "+test.Error)
 	}
 }
 
@@ -65,7 +65,7 @@ func TestInvalidEventDataError(t *testing.T) {
 		Key:  "TestInvalidEventDataErrorEventKey",
 		Data: tests.parameterTestsToMapData(),
 	}
-	require.Contains(t, "Data of event 'TestInvalidEventDataErrorEventKey' is invalid", err.Error())
+	require.Contains(t, err.Error(), "Data of event 'TestInvalidEventDataErrorEventKey' is invalid")
 	tests.assert(t, err.Error())
 }
 
@@ -95,7 +95,7 @@ func TestInvalidTaskInputError(t *testing.T) {
 		Key:    "TestInvalidTaskInputErrorEventKey",
 		Inputs: tests.parameterTestsToMapData(),
 	}
-	require.Contains(t, "Inputs of task 'TestInvalidTaskInputErrorEventKey' are invalid", err.Error())
+	require.Contains(t, err.Error(), "Inputs of task 'TestInvalidTaskInputErrorEventKey' are invalid")
 	tests.assert(t, err.Error())
 }
 
@@ -125,6 +125,6 @@ func TestInvalidOutputDataError(t *testing.T) {
 		Key:  "TestInvalidOutputDataErrorEventKey",
 		Data: tests.parameterTestsToMapData(),
 	}
-	require.Contains(t, "Outputs of task 'TestInvalidOutputDataErrorEventKey' are invalid", err.Error())
+	require.Contains(t, err.Error(), "Outputs of task 'TestInvalidOutputDataErrorEventKey' are invalid")
 	tests.assert(t, err.Error())
 }

--- a/service/hash_test.go
+++ b/service/hash_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateId(t *testing.T) {
@@ -11,7 +11,7 @@ func TestGenerateId(t *testing.T) {
 		Name: "TestGenerateId",
 	}
 	hash := service.Hash()
-	assert.Equal(t, string(hash), "v1_b3664cde5d7fcb2d37fe2ebb45acdd27")
+	require.Equal(t, string(hash), "v1_b3664cde5d7fcb2d37fe2ebb45acdd27")
 }
 
 func TestNoCollision(t *testing.T) {
@@ -23,5 +23,5 @@ func TestNoCollision(t *testing.T) {
 	}
 	hash1 := service1.Hash()
 	hash2 := service2.Hash()
-	assert.NotEqual(t, string(hash1), string(hash2))
+	require.NotEqual(t, string(hash1), string(hash2))
 }

--- a/service/importer/docker_file_test.go
+++ b/service/importer/docker_file_test.go
@@ -3,17 +3,17 @@ package importer
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadDockerFile(t *testing.T) {
 	data, err := readDockerfile("./tests/service-valid")
-	assert.Nil(t, err)
-	assert.True(t, (len(data) > 0))
+	require.Nil(t, err)
+	require.True(t, (len(data) > 0))
 }
 
 func TestReadDockerFileDoesNotExist(t *testing.T) {
 	data, err := readDockerfile("./tests/docker-missing")
-	assert.NotNil(t, err)
-	assert.True(t, (len(data) == 0))
+	require.NotNil(t, err)
+	require.True(t, (len(data) == 0))
 }

--- a/service/importer/import_test.go
+++ b/service/importer/import_test.go
@@ -3,27 +3,27 @@ package importer
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test From function
 
 func TestFrom(t *testing.T) {
 	service, err := From("./tests/service-minimal-valid")
-	assert.Nil(t, err)
-	assert.NotNil(t, service)
-	assert.Equal(t, service.Name, "minimal-valid")
+	require.Nil(t, err)
+	require.NotNil(t, service)
+	require.Equal(t, service.Name, "minimal-valid")
 }
 
 func TestFromMalFormattedFile(t *testing.T) {
 	_, err := From("./tests/service-file-mal-formatted")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestFromValidationError(t *testing.T) {
 	_, err := From("./tests/service-file-invalid")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	_, typeCasting := err.(*ValidationError)
-	assert.True(t, typeCasting)
-	assert.Equal(t, (&ValidationError{}).Error(), err.Error())
+	require.True(t, typeCasting)
+	require.Equal(t, (&ValidationError{}).Error(), err.Error())
 }

--- a/service/importer/service_file_test.go
+++ b/service/importer/service_file_test.go
@@ -3,7 +3,7 @@ package importer
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -11,14 +11,14 @@ import (
 
 func TestReadServiceFile(t *testing.T) {
 	data, err := readServiceFile("./tests/service-valid")
-	assert.Nil(t, err)
-	assert.True(t, (len(data) > 0))
+	require.Nil(t, err)
+	require.True(t, (len(data) > 0))
 }
 
 func TestReadServiceFileDoesNotExist(t *testing.T) {
 	data, err := readServiceFile("./tests/service-file-missing")
-	assert.NotNil(t, err)
-	assert.True(t, (len(data) == 0))
+	require.NotNil(t, err)
+	require.True(t, (len(data) == 0))
 }
 
 // Test validateServiceFileSchema function
@@ -29,8 +29,8 @@ func TestValidateServiceFileSchema(t *testing.T) {
 	_ = yaml.Unmarshal(data, &body)
 	body = convert(body)
 	result, err := validateServiceFileSchema(body, "service/importer/assets/schema.json")
-	assert.Nil(t, err)
-	assert.True(t, result.Valid())
+	require.Nil(t, err)
+	require.True(t, result.Valid())
 }
 
 func TestValidateServiceFileSchemaNotExisting(t *testing.T) {
@@ -39,7 +39,7 @@ func TestValidateServiceFileSchemaNotExisting(t *testing.T) {
 	_ = yaml.Unmarshal(data, &body)
 	body = convert(body)
 	_, err := validateServiceFileSchema(body, "service/assets/not_existing")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 // Test validateServiceFile function
@@ -47,27 +47,27 @@ func TestValidateServiceFileSchemaNotExisting(t *testing.T) {
 func TestValidateServiceFile(t *testing.T) {
 	data, _ := readServiceFile("./tests/service-valid")
 	warnings, err := validateServiceFile(data)
-	assert.Nil(t, err)
-	assert.True(t, (len(warnings) == 0))
+	require.Nil(t, err)
+	require.True(t, (len(warnings) == 0))
 }
 
 func TestValidateServiceFileMalFormatted(t *testing.T) {
 	data, _ := readServiceFile("./tests/service-file-mal-formatted")
 	warnings, err := validateServiceFile(data)
-	assert.NotNil(t, err)
-	assert.True(t, (len(warnings) == 0))
+	require.NotNil(t, err)
+	require.True(t, (len(warnings) == 0))
 }
 
 func TestValidateServiceFileWithErrors(t *testing.T) {
 	data, _ := readServiceFile("./tests/service-file-invalid")
 	warnings, err := validateServiceFile(data)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(warnings))
+	require.Nil(t, err)
+	require.Equal(t, 1, len(warnings))
 }
 
 func TestValidateServiceFileWithMultipleErrors(t *testing.T) {
 	data, _ := readServiceFile("./tests/service-multiple-errors")
 	warnings, err := validateServiceFile(data)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(warnings))
+	require.Nil(t, err)
+	require.Equal(t, 2, len(warnings))
 }

--- a/service/importer/validation_result_test.go
+++ b/service/importer/validation_result_test.go
@@ -3,7 +3,7 @@ package importer
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test ValidationResult.IsValid function
@@ -14,7 +14,7 @@ func TestValidationResultIsValid(t *testing.T) {
 		ServiceFileWarnings: []string{},
 		DockerfileExist:     true,
 	}
-	assert.True(t, v.IsValid())
+	require.True(t, v.IsValid())
 }
 
 func TestValidationResultIsValidServiceFileDoesNotExist(t *testing.T) {
@@ -23,7 +23,7 @@ func TestValidationResultIsValidServiceFileDoesNotExist(t *testing.T) {
 		ServiceFileWarnings: []string{},
 		DockerfileExist:     true,
 	}
-	assert.False(t, v.IsValid())
+	require.False(t, v.IsValid())
 }
 
 func TestValidationResultIsValidServiceFileWarnings(t *testing.T) {
@@ -32,7 +32,7 @@ func TestValidationResultIsValidServiceFileWarnings(t *testing.T) {
 		ServiceFileWarnings: []string{"Warning"},
 		DockerfileExist:     true,
 	}
-	assert.False(t, v.IsValid())
+	require.False(t, v.IsValid())
 }
 
 func TestValidationResultIsValidDockfileDoesNotExist(t *testing.T) {
@@ -41,5 +41,5 @@ func TestValidationResultIsValidDockfileDoesNotExist(t *testing.T) {
 		ServiceFileWarnings: []string{},
 		DockerfileExist:     false,
 	}
-	assert.False(t, v.IsValid())
+	require.False(t, v.IsValid())
 }

--- a/service/importer/validation_test.go
+++ b/service/importer/validation_test.go
@@ -3,70 +3,70 @@ package importer
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test Validate function
 
 func TestValidate(t *testing.T) {
 	validation, err := Validate("./tests/service-valid")
-	assert.Nil(t, err)
-	assert.True(t, validation.IsValid())
-	assert.True(t, validation.ServiceFileExist)
-	assert.Equal(t, 0, len(validation.ServiceFileWarnings))
-	assert.True(t, validation.DockerfileExist)
+	require.Nil(t, err)
+	require.True(t, validation.IsValid())
+	require.True(t, validation.ServiceFileExist)
+	require.Equal(t, 0, len(validation.ServiceFileWarnings))
+	require.True(t, validation.DockerfileExist)
 }
 
 func TestValidateDockerfileIsMissing(t *testing.T) {
 	validation, err := Validate("./tests/service-docker-missing")
-	assert.Nil(t, err)
-	assert.False(t, validation.IsValid())
-	assert.True(t, validation.ServiceFileExist)
-	assert.Equal(t, 0, len(validation.ServiceFileWarnings))
-	assert.False(t, validation.DockerfileExist)
+	require.Nil(t, err)
+	require.False(t, validation.IsValid())
+	require.True(t, validation.ServiceFileExist)
+	require.Equal(t, 0, len(validation.ServiceFileWarnings))
+	require.False(t, validation.DockerfileExist)
 }
 
 func TestValidateFromMissingServiceFile(t *testing.T) {
 	validation, err := Validate("./tests/service-file-missing")
-	assert.Nil(t, err)
-	assert.False(t, validation.IsValid())
-	assert.False(t, validation.ServiceFileExist)
-	assert.Equal(t, 1, len(validation.ServiceFileWarnings))
-	assert.True(t, validation.DockerfileExist)
+	require.Nil(t, err)
+	require.False(t, validation.IsValid())
+	require.False(t, validation.ServiceFileExist)
+	require.Equal(t, 1, len(validation.ServiceFileWarnings))
+	require.True(t, validation.DockerfileExist)
 }
 
 func TestValidateFromNonExistingPath(t *testing.T) {
 	validation, err := Validate("./tests/service-non-existing")
-	assert.Nil(t, err)
-	assert.False(t, validation.IsValid())
-	assert.False(t, validation.ServiceFileExist)
-	assert.Equal(t, 1, len(validation.ServiceFileWarnings))
-	assert.False(t, validation.DockerfileExist)
+	require.Nil(t, err)
+	require.False(t, validation.IsValid())
+	require.False(t, validation.ServiceFileExist)
+	require.Equal(t, 1, len(validation.ServiceFileWarnings))
+	require.False(t, validation.DockerfileExist)
 }
 
 func TestValidateFromMalFormattedServiceFile(t *testing.T) {
 	_, err := Validate("./tests/service-file-mal-formatted")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestValidateFromInvalidServiceFile(t *testing.T) {
 	validation, err := Validate("./tests/service-file-invalid")
-	assert.Nil(t, err)
-	assert.False(t, validation.IsValid())
-	assert.True(t, validation.ServiceFileExist)
-	assert.Equal(t, 1, len(validation.ServiceFileWarnings))
-	assert.True(t, validation.DockerfileExist)
+	require.Nil(t, err)
+	require.False(t, validation.IsValid())
+	require.True(t, validation.ServiceFileExist)
+	require.Equal(t, 1, len(validation.ServiceFileWarnings))
+	require.True(t, validation.DockerfileExist)
 }
 
 // Test IsValid function
 
 func TestIsValid(t *testing.T) {
 	isValid, err := IsValid("./tests/service-valid")
-	assert.Nil(t, err)
-	assert.True(t, isValid)
+	require.Nil(t, err)
+	require.True(t, isValid)
 }
 
 func TestIsValidMalFormattedServiceFile(t *testing.T) {
 	_, err := IsValid("./tests/service-file-mal-formatted")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }

--- a/service/logs_test.go
+++ b/service/logs_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogs(t *testing.T) {
@@ -21,8 +21,8 @@ func TestLogs(t *testing.T) {
 	service.Start()
 	defer service.Stop()
 	readers, err := service.Logs("*")
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(readers))
+	require.Nil(t, err)
+	require.Equal(t, 2, len(readers))
 }
 
 func TestLogsOnlyOneDependency(t *testing.T) {
@@ -40,6 +40,6 @@ func TestLogsOnlyOneDependency(t *testing.T) {
 	service.Start()
 	defer service.Stop()
 	readers, err := service.Logs("test2")
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(readers))
+	require.Nil(t, err)
+	require.Equal(t, 1, len(readers))
 }

--- a/service/namespace_test.go
+++ b/service/namespace_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/utils/hash"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServiceNamespace(t *testing.T) {
 	service := &Service{Name: "TestServiceNamespace"}
 	namespace := service.namespace()
-	assert.Equal(t, namespace, []string{service.Hash()})
+	require.Equal(t, namespace, []string{service.Hash()})
 }
 
 func TestDependencyNamespace(t *testing.T) {
@@ -24,12 +24,12 @@ func TestDependencyNamespace(t *testing.T) {
 	}
 	dep := service.DependenciesFromService()[0]
 	namespace := dep.namespace()
-	assert.Equal(t, namespace, []string{service.Hash(), "test"})
+	require.Equal(t, namespace, []string{service.Hash(), "test"})
 }
 
 func TestEventSubscriptionChannel(t *testing.T) {
 	service := &Service{Name: "TestEventSubscriptionChannel"}
-	assert.Equal(t, service.EventSubscriptionChannel(), hash.Calculate(append(
+	require.Equal(t, service.EventSubscriptionChannel(), hash.Calculate(append(
 		service.namespace(),
 		eventChannel,
 	)))
@@ -37,7 +37,7 @@ func TestEventSubscriptionChannel(t *testing.T) {
 
 func TestTaskSubscriptionChannel(t *testing.T) {
 	service := &Service{Name: "TaskSubscriptionChannel"}
-	assert.Equal(t, service.TaskSubscriptionChannel(), hash.Calculate(append(
+	require.Equal(t, service.TaskSubscriptionChannel(), hash.Calculate(append(
 		service.namespace(),
 		taskChannel,
 	)))
@@ -45,7 +45,7 @@ func TestTaskSubscriptionChannel(t *testing.T) {
 
 func TestResultSubscriptionChannel(t *testing.T) {
 	service := &Service{Name: "ResultSubscriptionChannel"}
-	assert.Equal(t, service.ResultSubscriptionChannel(), hash.Calculate(append(
+	require.Equal(t, service.ResultSubscriptionChannel(), hash.Calculate(append(
 		service.namespace(),
 		resultChannel,
 	)))

--- a/service/start_test.go
+++ b/service/start_test.go
@@ -5,13 +5,13 @@ import (
 	"time"
 
 	"github.com/mesg-foundation/core/container"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractPortEmpty(t *testing.T) {
 	dep := Dependency{}
 	ports := dep.extractPorts()
-	assert.Equal(t, len(ports), 0)
+	require.Equal(t, len(ports), 0)
 }
 
 func TestExtractPorts(t *testing.T) {
@@ -22,11 +22,11 @@ func TestExtractPorts(t *testing.T) {
 		},
 	}
 	ports := dep.extractPorts()
-	assert.Equal(t, len(ports), 2)
-	assert.Equal(t, ports[0].Target, uint32(80))
-	assert.Equal(t, ports[0].Published, uint32(80))
-	assert.Equal(t, ports[1].Target, uint32(8080))
-	assert.Equal(t, ports[1].Published, uint32(3000))
+	require.Equal(t, len(ports), 2)
+	require.Equal(t, ports[0].Target, uint32(80))
+	require.Equal(t, ports[0].Published, uint32(80))
+	require.Equal(t, ports[1].Target, uint32(8080))
+	require.Equal(t, ports[1].Published, uint32(3000))
 }
 
 func TestStartService(t *testing.T) {
@@ -40,10 +40,10 @@ func TestStartService(t *testing.T) {
 	}
 	dockerServices, err := service.Start()
 	defer service.Stop()
-	assert.Nil(t, err)
-	assert.Equal(t, len(service.GetDependencies()), len(dockerServices))
+	require.Nil(t, err)
+	require.Equal(t, len(service.GetDependencies()), len(dockerServices))
 	status, _ := service.Status()
-	assert.Equal(t, RUNNING, status)
+	require.Equal(t, RUNNING, status)
 }
 
 func TestStartWith2Dependencies(t *testing.T) {
@@ -60,13 +60,13 @@ func TestStartWith2Dependencies(t *testing.T) {
 	}
 	servicesID, err := service.Start()
 	defer service.Stop()
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(servicesID))
+	require.Nil(t, err)
+	require.Equal(t, 2, len(servicesID))
 	deps := service.DependenciesFromService()
 	container1, _ := defaultContainer.FindContainer(deps[0].namespace())
 	container2, _ := defaultContainer.FindContainer(deps[1].namespace())
-	assert.Equal(t, "nginx:latest", container1.Config.Image)
-	assert.Equal(t, "alpine:latest", container2.Config.Image)
+	require.Equal(t, "nginx:latest", container1.Config.Image)
+	require.Equal(t, "alpine:latest", container2.Config.Image)
 }
 
 func TestStartAgainService(t *testing.T) {
@@ -81,10 +81,10 @@ func TestStartAgainService(t *testing.T) {
 	service.Start()
 	defer service.Stop()
 	dockerServices, err := service.Start()
-	assert.Nil(t, err)
-	assert.Equal(t, len(dockerServices), 0) // 0 because already started so no new one to start
+	require.Nil(t, err)
+	require.Equal(t, len(dockerServices), 0) // 0 because already started so no new one to start
 	status, _ := service.Status()
-	assert.Equal(t, RUNNING, status)
+	require.Equal(t, RUNNING, status)
 }
 
 func TestPartiallyRunningService(t *testing.T) {
@@ -103,12 +103,12 @@ func TestPartiallyRunningService(t *testing.T) {
 	defer service.Stop()
 	service.DependenciesFromService()[0].Stop()
 	status, _ := service.Status()
-	assert.Equal(t, PARTIAL, status)
+	require.Equal(t, PARTIAL, status)
 	dockerServices, err := service.Start()
-	assert.Nil(t, err)
-	assert.Equal(t, len(dockerServices), len(service.GetDependencies()))
+	require.Nil(t, err)
+	require.Equal(t, len(dockerServices), len(service.GetDependencies()))
 	status, _ = service.Status()
-	assert.Equal(t, RUNNING, status)
+	require.Equal(t, RUNNING, status)
 }
 
 func TestStartDependency(t *testing.T) {
@@ -125,10 +125,10 @@ func TestStartDependency(t *testing.T) {
 	dep := service.DependenciesFromService()[0]
 	serviceID, err := dep.Start(networkID)
 	defer dep.Stop()
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", serviceID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", serviceID)
 	status, _ := dep.Status()
-	assert.Equal(t, container.RUNNING, status)
+	require.Equal(t, container.RUNNING, status)
 }
 
 func TestNetworkCreated(t *testing.T) {
@@ -143,8 +143,8 @@ func TestNetworkCreated(t *testing.T) {
 	service.Start()
 	defer service.Stop()
 	network, err := defaultContainer.FindNetwork(service.namespace())
-	assert.Nil(t, err)
-	assert.NotEqual(t, "", network.ID)
+	require.Nil(t, err)
+	require.NotEqual(t, "", network.ID)
 }
 
 // Test for https://github.com/mesg-foundation/core/issues/88
@@ -162,8 +162,8 @@ func TestStartStopStart(t *testing.T) {
 	time.Sleep(10 * time.Second)
 	dockerServices, err := service.Start()
 	defer service.Stop()
-	assert.Nil(t, err)
-	assert.Equal(t, len(dockerServices), 1)
+	require.Nil(t, err)
+	require.Equal(t, len(dockerServices), 1)
 	status, _ := service.Status()
-	assert.Equal(t, RUNNING, status)
+	require.Equal(t, RUNNING, status)
 }

--- a/service/status_test.go
+++ b/service/status_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/container"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStatusService(t *testing.T) {
@@ -17,15 +17,15 @@ func TestStatusService(t *testing.T) {
 		},
 	}
 	status, err := service.Status()
-	assert.Nil(t, err)
-	assert.Equal(t, STOPPED, status)
+	require.Nil(t, err)
+	require.Equal(t, STOPPED, status)
 	dockerServices, err := service.Start()
 	defer service.Stop()
-	assert.Nil(t, err)
-	assert.Equal(t, len(dockerServices), len(service.GetDependencies()))
+	require.Nil(t, err)
+	require.Equal(t, len(dockerServices), len(service.GetDependencies()))
 	status, err = service.Status()
-	assert.Nil(t, err)
-	assert.Equal(t, RUNNING, status)
+	require.Nil(t, err)
+	require.Equal(t, RUNNING, status)
 }
 
 func TestStatusDependency(t *testing.T) {
@@ -39,14 +39,14 @@ func TestStatusDependency(t *testing.T) {
 	}
 	dep := service.DependenciesFromService()[0]
 	status, err := dep.Status()
-	assert.Nil(t, err)
-	assert.Equal(t, container.STOPPED, status)
+	require.Nil(t, err)
+	require.Equal(t, container.STOPPED, status)
 	dockerServices, err := service.Start()
-	assert.Nil(t, err)
-	assert.Equal(t, len(dockerServices), len(service.GetDependencies()))
+	require.Nil(t, err)
+	require.Equal(t, len(dockerServices), len(service.GetDependencies()))
 	status, err = dep.Status()
-	assert.Nil(t, err)
-	assert.Equal(t, container.RUNNING, status)
+	require.Nil(t, err)
+	require.Equal(t, container.RUNNING, status)
 	service.Stop()
 }
 
@@ -63,9 +63,9 @@ func TestList(t *testing.T) {
 	service.Start()
 	defer service.Stop()
 	list, err := ListRunning()
-	assert.Nil(t, err)
-	assert.Equal(t, len(list), 1)
-	assert.Equal(t, list[0], hash)
+	require.Nil(t, err)
+	require.Equal(t, len(list), 1)
+	require.Equal(t, list[0], hash)
 }
 
 func TestListMultipleDependencies(t *testing.T) {
@@ -84,7 +84,7 @@ func TestListMultipleDependencies(t *testing.T) {
 	service.Start()
 	defer service.Stop()
 	list, err := ListRunning()
-	assert.Nil(t, err)
-	assert.Equal(t, len(list), 1)
-	assert.Equal(t, list[0], hash)
+	require.Nil(t, err)
+	require.Equal(t, len(list), 1)
+	require.Equal(t, list[0], hash)
 }

--- a/service/stop_test.go
+++ b/service/stop_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/mesg-foundation/core/container"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStopRunningService(t *testing.T) {
@@ -19,9 +19,9 @@ func TestStopRunningService(t *testing.T) {
 	}
 	service.Start()
 	err := service.Stop()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	status, _ := service.Status()
-	assert.Equal(t, STOPPED, status)
+	require.Equal(t, STOPPED, status)
 }
 
 func TestStopNonRunningService(t *testing.T) {
@@ -34,9 +34,9 @@ func TestStopNonRunningService(t *testing.T) {
 		},
 	}
 	err := service.Stop()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	status, _ := service.Status()
-	assert.Equal(t, STOPPED, status)
+	require.Equal(t, STOPPED, status)
 }
 
 func TestStopDependency(t *testing.T) {
@@ -53,9 +53,9 @@ func TestStopDependency(t *testing.T) {
 	dep := service.DependenciesFromService()[0]
 	dep.Start(networkID)
 	err = dep.Stop()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	status, _ := dep.Status()
-	assert.Equal(t, container.STOPPED, status)
+	require.Equal(t, container.STOPPED, status)
 }
 
 func TestNetworkDeleted(t *testing.T) {
@@ -71,5 +71,5 @@ func TestNetworkDeleted(t *testing.T) {
 	service.Stop()
 	time.Sleep(5 * time.Second)
 	_, err := defaultContainer.FindNetwork(service.namespace())
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }

--- a/service/validation_test.go
+++ b/service/validation_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var serviceTest = &Service{
@@ -33,42 +33,42 @@ var serviceTest = &Service{
 var event = serviceTest.Events["test"]
 
 func TestRequired(t *testing.T) {
-	assert.Nil(t, event.Data["optional"].Validate("presence"))
-	assert.Nil(t, event.Data["optional"].Validate(nil))
+	require.Nil(t, event.Data["optional"].Validate("presence"))
+	require.Nil(t, event.Data["optional"].Validate(nil))
 	// this parameter is required
-	assert.NotNil(t, event.Data["string"].Validate(nil))
+	require.NotNil(t, event.Data["string"].Validate(nil))
 }
 
 func TestString(t *testing.T) {
-	assert.Nil(t, event.Data["string"].Validate("valid"))
-	assert.NotNil(t, event.Data["string"].Validate(false))
+	require.Nil(t, event.Data["string"].Validate("valid"))
+	require.NotNil(t, event.Data["string"].Validate(false))
 }
 
 func TestNumber(t *testing.T) {
-	assert.Nil(t, event.Data["number"].Validate(10.5))
-	assert.Nil(t, event.Data["number"].Validate(10))
-	assert.NotNil(t, event.Data["number"].Validate("not a number"))
+	require.Nil(t, event.Data["number"].Validate(10.5))
+	require.Nil(t, event.Data["number"].Validate(10))
+	require.NotNil(t, event.Data["number"].Validate("not a number"))
 }
 
 func TestBoolean(t *testing.T) {
-	assert.Nil(t, event.Data["boolean"].Validate(true))
-	assert.Nil(t, event.Data["boolean"].Validate(false))
-	assert.NotNil(t, event.Data["boolean"].Validate("not a boolean"))
+	require.Nil(t, event.Data["boolean"].Validate(true))
+	require.Nil(t, event.Data["boolean"].Validate(false))
+	require.NotNil(t, event.Data["boolean"].Validate("not a boolean"))
 }
 
 func TestObject(t *testing.T) {
-	assert.Nil(t, event.Data["object"].Validate(map[string]interface{}{
+	require.Nil(t, event.Data["object"].Validate(map[string]interface{}{
 		"foo": "bar",
 	}))
-	assert.Nil(t, event.Data["object"].Validate([]interface{}{
+	require.Nil(t, event.Data["object"].Validate([]interface{}{
 		"foo",
 		"bar",
 	}))
-	assert.NotNil(t, event.Data["object"].Validate(42))
+	require.NotNil(t, event.Data["object"].Validate(42))
 }
 
 func TestValidateParameters(t *testing.T) {
-	assert.Equal(t, 0, len(validateParameters(event.Data, map[string]interface{}{
+	require.Equal(t, 0, len(validateParameters(event.Data, map[string]interface{}{
 		"string":  "hello",
 		"number":  10,
 		"boolean": true,
@@ -76,7 +76,7 @@ func TestValidateParameters(t *testing.T) {
 			"foo": "bar",
 		},
 	})))
-	assert.Equal(t, 0, len(validateParameters(event.Data, map[string]interface{}{
+	require.Equal(t, 0, len(validateParameters(event.Data, map[string]interface{}{
 		"optional": "yeah",
 		"string":   "hello",
 		"number":   10,
@@ -90,7 +90,7 @@ func TestValidateParameters(t *testing.T) {
 	//  - invalid number
 	//  - invalid boolean
 	//  - invalid object
-	assert.Equal(t, 4, len(validateParameters(event.Data, map[string]interface{}{
+	require.Equal(t, 4, len(validateParameters(event.Data, map[string]interface{}{
 		"number":  "string",
 		"boolean": 42,
 		"object":  false,
@@ -98,7 +98,7 @@ func TestValidateParameters(t *testing.T) {
 }
 
 func TestValidParameters(t *testing.T) {
-	assert.True(t, validParameters(event.Data, map[string]interface{}{
+	require.True(t, validParameters(event.Data, map[string]interface{}{
 		"string":  "hello",
 		"number":  10,
 		"boolean": true,
@@ -106,5 +106,5 @@ func TestValidParameters(t *testing.T) {
 			"foo": "bar",
 		},
 	}))
-	assert.False(t, validParameters(event.Data, map[string]interface{}{}))
+	require.False(t, validParameters(event.Data, map[string]interface{}{}))
 }

--- a/utils/array/include_test.go
+++ b/utils/array/include_test.go
@@ -3,16 +3,16 @@ package array
 import (
 	"testing"
 
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIncludedIn(t *testing.T) {
-	assert.False(t, IncludedIn([]string{}, ""))
-	assert.True(t, IncludedIn([]string{""}, ""))
-	assert.False(t, IncludedIn([]string{"a"}, ""))
-	assert.True(t, IncludedIn([]string{"a"}, "a"))
-	assert.False(t, IncludedIn([]string{""}, "a"))
-	assert.True(t, IncludedIn([]string{"a", "b"}, "a"))
-	assert.True(t, IncludedIn([]string{"a", "b"}, "b"))
-	assert.False(t, IncludedIn([]string{"a", "b"}, "c"))
+	require.False(t, IncludedIn([]string{}, ""))
+	require.True(t, IncludedIn([]string{""}, ""))
+	require.False(t, IncludedIn([]string{"a"}, ""))
+	require.True(t, IncludedIn([]string{"a"}, "a"))
+	require.False(t, IncludedIn([]string{""}, "a"))
+	require.True(t, IncludedIn([]string{"a", "b"}, "a"))
+	require.True(t, IncludedIn([]string{"a", "b"}, "b"))
+	require.False(t, IncludedIn([]string{"a", "b"}, "c"))
 }


### PR DESCRIPTION
What do you think about replacing `github.com/stvp/assert` with `github.com/stretchr/testify/require`

It has the same API but with way more features:

- Zero asserts that i is the zero value for its type.
- test if dir/file exists
- HTTP testing (in the future)
- test if objects are equal
- test regexp
- test time duration
- test JSON as a string
- more ...

PR is done and only needs to merge.

@mesg-foundation/core What do you think?