### PR TITLE
fix goroutine leaks on stream handlers of api package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - (#303) Deprecate command `service test` in favor of `service dev` and `service execute`
 
 #### Fixed
+- (#358) Fix gorutinue leaks on api package handlers where gRPC streams are used. Handlers were blocking forever because of not respecting to context cancellation and stream.Send() errors.
 
 ## [v1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - (#303) Deprecate command `service test` in favor of `service dev` and `service execute`
 
 #### Fixed
-- (#358) Fix gorutinue leaks on api package handlers where gRPC streams are used. Handlers were blocking forever because of not respecting to context cancellation and stream.Send() errors.
+- (#358) Fix goroutine leaks on api package handlers where gRPC streams are used. Handlers now doesn't block forever by exiting on context cancellation and stream.Send() errors.
 
 ## [v1.0.0]
 

--- a/api/core/listen_result.go
+++ b/api/core/listen_result.go
@@ -23,20 +23,31 @@ func (s *Server) ListenResult(request *ListenResultRequest, stream Core_ListenRe
 	if err := validateOutputKey(&service, request.TaskFilter, request.OutputFilter); err != nil {
 		return err
 	}
-	subscription := pubsub.Subscribe(service.ResultSubscriptionChannel())
-	for data := range subscription {
-		execution := data.(*execution.Execution)
-		if isSubscribedTask(request, execution) && isSubscribedOutput(request, execution) {
-			outputs, _ := json.Marshal(execution.OutputData)
-			stream.Send(&ResultData{
-				ExecutionID: execution.ID,
-				TaskKey:     execution.Task,
-				OutputKey:   execution.Output,
-				OutputData:  string(outputs),
-			})
+
+	ctx := stream.Context()
+	channel := service.ResultSubscriptionChannel()
+	subscription := pubsub.Subscribe(channel)
+	defer pubsub.Unsubscribe(channel, subscription)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case data := <-subscription:
+			execution := data.(*execution.Execution)
+			if isSubscribedTask(request, execution) && isSubscribedOutput(request, execution) {
+				outputs, _ := json.Marshal(execution.OutputData)
+				if err := stream.Send(&ResultData{
+					ExecutionID: execution.ID,
+					TaskKey:     execution.Task,
+					OutputKey:   execution.Output,
+					OutputData:  string(outputs),
+				}); err != nil {
+					return err
+				}
+			}
 		}
 	}
-	return nil
 }
 
 func validateTaskKey(service *service.Service, taskKey string) error {

--- a/api/core/listen_result.go
+++ b/api/core/listen_result.go
@@ -17,10 +17,7 @@ func (s *Server) ListenResult(request *ListenResultRequest, stream Core_ListenRe
 	if err != nil {
 		return err
 	}
-	if err := validateTaskKey(&service, request.TaskFilter); err != nil {
-		return err
-	}
-	if err := validateOutputKey(&service, request.TaskFilter, request.OutputFilter); err != nil {
+	if err := validateTask(&service, request); err != nil {
 		return err
 	}
 
@@ -48,6 +45,13 @@ func (s *Server) ListenResult(request *ListenResultRequest, stream Core_ListenRe
 			}
 		}
 	}
+}
+
+func validateTask(service *service.Service, request *ListenResultRequest) error {
+	if err := validateTaskKey(service, request.TaskFilter); err != nil {
+		return err
+	}
+	return validateOutputKey(service, request.TaskFilter, request.OutputFilter)
 }
 
 func validateTaskKey(service *service.Service, taskKey string) error {

--- a/api/service/listen_task.go
+++ b/api/service/listen_task.go
@@ -14,15 +14,26 @@ func (s *Server) ListenTask(request *ListenTaskRequest, stream Service_ListenTas
 	if err != nil {
 		return err
 	}
-	subscription := pubsub.Subscribe(service.TaskSubscriptionChannel())
-	for data := range subscription {
-		execution := data.(*execution.Execution)
-		inputs, _ := json.Marshal(execution.Inputs)
-		stream.Send(&TaskData{
-			ExecutionID: execution.ID,
-			TaskKey:     execution.Task,
-			InputData:   string(inputs),
-		})
+
+	ctx := stream.Context()
+	channel := service.TaskSubscriptionChannel()
+	subscription := pubsub.Subscribe(channel)
+	defer pubsub.Unsubscribe(channel, subscription)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case data := <-subscription:
+			execution := data.(*execution.Execution)
+			inputs, _ := json.Marshal(execution.Inputs)
+			if err := stream.Send(&TaskData{
+				ExecutionID: execution.ID,
+				TaskKey:     execution.Task,
+				InputData:   string(inputs),
+			}); err != nil {
+				return err
+			}
+		}
 	}
-	return nil
 }

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -34,3 +34,15 @@ func Subscribe(channel string) chan Message {
 	mu.Unlock()
 	return listener
 }
+
+// Unsubscribe unsubscribes a subscription for listening channel.
+func Unsubscribe(channel string, subscription chan Message) {
+	mu.Lock()
+	defer mu.Unlock()
+	for i, s := range listeners[channel] {
+		if s == subscription {
+			listeners[channel] = append(listeners[channel][:i], listeners[channel][i+1:]...)
+			return
+		}
+	}
+}

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -37,13 +37,12 @@ func Subscribe(channel string) chan Message {
 func Unsubscribe(channel string, listener chan Message) {
 	mu.Lock()
 	defer mu.Unlock()
-	if len(listeners[channel]) == 1 {
-		listeners[channel] = nil
-		return
-	}
 	for i, l := range listeners[channel] {
 		if l == listener {
 			listeners[channel] = append(listeners[channel][:i], listeners[channel][i+1:]...)
+			if len(listeners[channel]) == 0 {
+				listeners[channel] = nil
+			}
 			return
 		}
 	}

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -15,32 +15,34 @@ type Message interface{}
 // Publish publishes a message to a channel.
 func Publish(channel string, data Message) {
 	mu.Lock()
+	defer mu.Unlock()
 	for _, listener := range listeners[channel] {
-		if listener != nil {
-			listener <- data
-		}
+		listener <- data
 	}
-	mu.Unlock()
 }
 
 // Subscribe subscribes to the channel and returns listener for it.
 func Subscribe(channel string) chan Message {
-	listener := make(chan Message)
 	mu.Lock()
+	defer mu.Unlock()
+	listener := make(chan Message)
 	if listeners[channel] == nil {
 		listeners[channel] = make([]chan Message, 0)
 	}
 	listeners[channel] = append(listeners[channel], listener)
-	mu.Unlock()
 	return listener
 }
 
-// Unsubscribe unsubscribes a subscription for listening channel.
-func Unsubscribe(channel string, subscription chan Message) {
+// Unsubscribe unsubscribes a listener from listening channel.
+func Unsubscribe(channel string, listener chan Message) {
 	mu.Lock()
 	defer mu.Unlock()
-	for i, s := range listeners[channel] {
-		if s == subscription {
+	if len(listeners[channel]) == 1 {
+		listeners[channel] = nil
+		return
+	}
+	for i, l := range listeners[channel] {
+		if l == listener {
 			listeners[channel] = append(listeners[channel][:i], listeners[channel][i+1:]...)
 			return
 		}

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -52,6 +52,8 @@ func TestUnsubscribe(t *testing.T) {
 	channel1 := Subscribe(key)
 	Unsubscribe(key, channel)
 	assert.Equal(t, len(listeners[key]), 1)
+	assert.NotNil(t, listeners[key])
 	Unsubscribe(key, channel1)
 	assert.Equal(t, len(listeners[key]), 0)
+	assert.Nil(t, listeners[key])
 }

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -45,3 +45,13 @@ func TestSubscribeMultipleTimes(t *testing.T) {
 	Subscribe(key)
 	assert.Equal(t, len(listeners[key]), 2)
 }
+
+func TestUnsubscribe(t *testing.T) {
+	key := "TestUnsubscribe"
+	channel := Subscribe(key)
+	channel1 := Subscribe(key)
+	Unsubscribe(key, channel)
+	assert.Equal(t, len(listeners[key]), 1)
+	Unsubscribe(key, channel1)
+	assert.Equal(t, len(listeners[key]), 0)
+}


### PR DESCRIPTION
There are goroutine leaks in the api handlers where gRPC streams used. When client disconnects or cancels, api handlers will keep running forever. This PR fixes this.

Btw, I don't understand why we compare chans with nil [here](https://github.com/mesg-foundation/core/blob/403153e5f7cbb3d8911814d064be9b5ced277a95/pubsub/pubsub.go#L19)