### PR TITLE
container: remove timeouts for long-lived Docker API calls, fixes #360

### DIFF
--- a/container/build.go
+++ b/container/build.go
@@ -31,9 +31,7 @@ func (c *Container) Build(path string) (tag string, err error) {
 		return "", err
 	}
 	defer buildContext.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), c.callTimeout)
-	defer cancel()
-	response, err := c.client.ImageBuild(ctx, buildContext, types.ImageBuildOptions{
+	response, err := c.client.ImageBuild(context.Background(), buildContext, types.ImageBuildOptions{
 		Remove:         true,
 		ForceRemove:    true,
 		SuppressOutput: true,

--- a/container/service.go
+++ b/container/service.go
@@ -72,9 +72,7 @@ func (c *Container) ServiceStatus(namespace []string) (StatusType, error) {
 
 // ServiceLogs returns the logs of a service.
 func (c *Container) ServiceLogs(namespace []string) (io.ReadCloser, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.callTimeout)
-	defer cancel()
-	return c.client.ServiceLogs(ctx, Namespace(namespace),
+	return c.client.ServiceLogs(context.Background(), Namespace(namespace),
 		types.ContainerLogsOptions{
 			ShowStdout: true,
 			ShowStderr: true,

--- a/container/shared_network_test.go
+++ b/container/shared_network_test.go
@@ -73,7 +73,7 @@ func TestCreateSharedNetworkIfNeededExists(t *testing.T) {
 	}
 }
 
-func TestIntegrationSharedNetworkID(t *testing.T) {
+func TestSharedNetworkID(t *testing.T) {
 	id := "1"
 	dt := dockertest.New()
 	c, _ := New(ClientOption(dt.Client()))


### PR DESCRIPTION
also tested with `./dev-core` and `./dev-cli`