### PR TITLE
fix button position on documentation

### DIFF
--- a/docs/.vuepress/style.styl
+++ b/docs/.vuepress/style.styl
@@ -17,7 +17,6 @@ header.navbar
       color white
   .sidebar-button
     color #eee
-    top 1.6rem
 
 .home .hero
   img


### PR DESCRIPTION
fix #318

quick PR just to fix the menu in the documentation in mobile

from 
<img width="132" alt="screen shot 2018-08-16 at 10 32 20 am" src="https://user-images.githubusercontent.com/1783126/44183915-a222c780-a13f-11e8-9205-2dd7f90faede.png">

to 

<img width="145" alt="screen shot 2018-08-16 at 10 32 25 am" src="https://user-images.githubusercontent.com/1783126/44183931-ae0e8980-a13f-11e8-983b-733f0b867eef.png">
