### PR TITLE
TestDependenciesListensFromSamePort test added for service package

### DIFF
--- a/service/start.go
+++ b/service/start.go
@@ -50,7 +50,7 @@ func (service *Service) Start() (serviceIDs []string, err error) {
 		}(dependency, i)
 	}
 	wg.Wait()
-	// Grasfully stop the service because there is an error
+	// Gracefully stop the service because there is an error
 	if err != nil {
 		service.Stop()
 	}

--- a/service/status_test.go
+++ b/service/status_test.go
@@ -88,3 +88,34 @@ func TestListMultipleDependencies(t *testing.T) {
 	require.Equal(t, len(list), 1)
 	require.Equal(t, list[0], hash)
 }
+
+func TestServiceDependenciesListensFromSamePort(t *testing.T) {
+	var (
+		service = &Service{
+			Name: "TestServiceDependenciesListensFromSamePort",
+			Dependencies: map[string]*Dependency{
+				"test": {
+					Image: "nginx",
+					Ports: []string{"80"},
+				},
+			},
+		}
+
+		service1 = &Service{
+			Name: "TestServiceDependenciesListensFromSamePort1",
+			Dependencies: map[string]*Dependency{
+				"test": {
+					Image: "nginx",
+					Ports: []string{"80"},
+				},
+			},
+		}
+	)
+	_, err := service.Start()
+	require.NoError(t, err)
+	defer service.Stop()
+
+	_, err = service1.Start()
+	require.NotZero(t, err)
+	require.Contains(t, err.Error(), `port '80' is already in use`)
+}


### PR DESCRIPTION
it seems waiting for https://github.com/mesg-foundation/core/pull/371 not needed, so here is a PR