### PR TITLE
Build using go tools instead of xgo

### DIFF
--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -1,11 +1,17 @@
 #!/bin/bash -e
 
 go get ./...
-go get github.com/karalabe/xgo
-mkdir bin
-xgo --targets=darwin/386,darwin/amd64,linux/386,linux/amd64,windows/386,windows/amd64 \
-  -ldflags="-X 'github.com/mesg-foundation/core/version.Version=$1'" \
-  -out mesg-core \
-  -dest ./bin \
-  ./interface/cli
-sudo chmod +x ./bin/*
+mkdir -p bin
+
+archs=(amd64 386)
+oss=(linux darwin)
+
+for os in ${oss[*]}; do
+  for arch in ${archs[*]}; do
+    echo "Building $os $arch..."
+    GOOS=$os GOARCH=$arch go build \
+      -o ./bin/mesg-core-$os-$arch \
+      -ldflags="-X 'github.com/mesg-foundation/core/version.Version=$1'" \
+      ./interface/cli
+  done
+done


### PR DESCRIPTION
Right now we were using xgo mostly because at first we had a dependency with ethereum that included some specific encryption libraries that needed to be installed in their own environment. Now we don't have such dependencies.

Also right now the build is failing on the CI. It seems because of some dependencies that might had change so this is another reason to move away from xgo.

Also go1.11 included the wasm support so we could easily later add the build for that