### PR TITLE
Fix container status info, closes #293

### DIFF
--- a/daemon/status.go
+++ b/daemon/status.go
@@ -6,5 +6,19 @@ import (
 
 // Status returns the Status of the docker service of the daemon.
 func Status() (container.StatusType, error) {
-	return defaultContainer.ServiceStatus(Namespace()) //TODO: should it be containerStatus?
+	//TODO: should it be containerStatus?
+	serviceStatus, err := defaultContainer.ServiceStatus(Namespace())
+	if err != nil {
+		return container.STOPPED, err
+	}
+
+	containerStatus, err := defaultContainer.Status(Namespace())
+	if err != nil {
+		return container.STOPPED, err
+	}
+
+	if serviceStatus == containerStatus {
+		return serviceStatus, nil
+	}
+	return container.STOPPED, nil
 }


### PR DESCRIPTION
https://github.com/mesg-foundation/core/issues/293

To think, should we have `unknown` status? or print both statuses (or have verbose mode). 

For now, it fixes the pbm.