### PR TITLE
Use docker volumes and not binding for services

### DIFF
--- a/config/api.go
+++ b/config/api.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/mesg-foundation/core/version"
@@ -11,14 +10,12 @@ import (
 
 // All the configuration keys.
 const (
-	APIServerAddress  = "Api.Server.Address"
-	APIClientTarget   = "Api.Client.Target"
-	LogFormat         = "Log.Format"
-	LogLevel          = "Log.Level"
-	ServicePathHost   = "Service.Path.Host"
-	ServicePathDocker = "Service.Path.Docker"
-	MESGPath          = "MESG.Path"
-	CoreImage         = "Core.Image"
+	APIServerAddress = "Api.Server.Address"
+	APIClientTarget  = "Api.Client.Target"
+	LogFormat        = "Log.Format"
+	LogLevel         = "Log.Level"
+	MESGPath         = "MESG.Path"
+	CoreImage        = "Core.Image"
 )
 
 func setAPIDefault() {
@@ -33,10 +30,6 @@ func setAPIDefault() {
 
 	viper.SetDefault(LogFormat, "text")
 	viper.SetDefault(LogLevel, "info")
-
-	viper.SetDefault(ServicePathHost, filepath.Join(viper.GetString(MESGPath), "services"))
-	viper.SetDefault(ServicePathDocker, filepath.Join("/mesg", "services"))
-	os.MkdirAll(viper.GetString(ServicePathDocker), os.ModePerm)
 
 	// Keep only the first part if Version contains space
 	coreTag := strings.Split(version.Version, " ")

--- a/config/api_test.go
+++ b/config/api_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -15,11 +14,9 @@ func assertViperDefault(t *testing.T, key string, expected string) {
 
 func TestAPIDefault(t *testing.T) {
 	defaults := map[string]string{
-		APIServerAddress:  ":50052",
-		LogFormat:         "text",
-		LogLevel:          "info",
-		ServicePathHost:   filepath.Join(viper.GetString(MESGPath), "services"),
-		ServicePathDocker: filepath.Join("/mesg", "services"),
+		APIServerAddress: ":50052",
+		LogFormat:        "text",
+		LogLevel:         "info",
 	}
 	for key, defaultValue := range defaults {
 		assertViperDefault(t, key, defaultValue)

--- a/container/service_options.go
+++ b/container/service_options.go
@@ -30,6 +30,7 @@ type Port struct {
 type Mount struct {
 	Source string
 	Target string
+	Bind   bool
 }
 
 func (options *ServiceOptions) toSwarmServiceSpec() swarm.ServiceSpec {
@@ -81,9 +82,14 @@ func (options *ServiceOptions) swarmMounts(force bool) []mount.Mount {
 	}
 	mounts := make([]mount.Mount, len(options.Mounts))
 	for i, m := range options.Mounts {
+		mountType := mount.TypeVolume
+		if m.Bind {
+			mountType = mount.TypeBind
+		}
 		mounts[i] = mount.Mount{
 			Source: m.Source,
 			Target: m.Target,
+			Type:   mountType,
 		}
 	}
 	return mounts

--- a/daemon/const.go
+++ b/daemon/const.go
@@ -3,6 +3,8 @@ package daemon
 const (
 	name         = "core"
 	dockerSocket = "/var/run/docker.sock"
+	volume       = "mesg-core"
+	path         = "/mesg"
 )
 
 // Namespace returns the namespace of the MESG Core.

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -35,7 +35,7 @@ func serviceSpec() (spec container.ServiceOptions, err error) {
 		Namespace: Namespace(),
 		Image:     viper.GetString(config.CoreImage),
 		Env: container.MapToEnv(map[string]string{
-			config.ToEnv(config.MESGPath):  "/mesg",
+			config.ToEnv(config.MESGPath):  path,
 			config.ToEnv(config.LogFormat): viper.GetString(config.LogFormat),
 			config.ToEnv(config.LogLevel):  viper.GetString(config.LogLevel),
 		}),
@@ -46,8 +46,8 @@ func serviceSpec() (spec container.ServiceOptions, err error) {
 				Bind:   true,
 			},
 			{
-				Source: "mesg-core",
-				Target: "/mesg",
+				Source: volume,
+				Target: path,
 			},
 		},
 		Ports: []container.Port{

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -46,9 +46,10 @@ func serviceSpec() (spec container.ServiceOptions, err error) {
 			{
 				Source: dockerSocket,
 				Target: dockerSocket,
+				Bind:   true,
 			},
 			{
-				Source: viper.GetString(config.MESGPath),
+				Source: "mesg-core",
 				Target: "/mesg",
 			},
 		},

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -1,8 +1,6 @@
 package daemon
 
 import (
-	"path/filepath"
-
 	"github.com/mesg-foundation/core/config"
 	"github.com/mesg-foundation/core/container"
 	"github.com/mesg-foundation/core/x/xnet"
@@ -37,10 +35,9 @@ func serviceSpec() (spec container.ServiceOptions, err error) {
 		Namespace: Namespace(),
 		Image:     viper.GetString(config.CoreImage),
 		Env: container.MapToEnv(map[string]string{
-			config.ToEnv(config.MESGPath):        "/mesg",
-			config.ToEnv(config.LogFormat):       viper.GetString(config.LogFormat),
-			config.ToEnv(config.LogLevel):        viper.GetString(config.LogLevel),
-			config.ToEnv(config.ServicePathHost): filepath.Join(viper.GetString(config.MESGPath), "services"),
+			config.ToEnv(config.MESGPath):  "/mesg",
+			config.ToEnv(config.LogFormat): viper.GetString(config.LogFormat),
+			config.ToEnv(config.LogLevel):  viper.GetString(config.LogLevel),
 		}),
 		Mounts: []container.Mount{
 			{

--- a/daemon/start_test.go
+++ b/daemon/start_test.go
@@ -1,12 +1,9 @@
 package daemon
 
 import (
-	"path/filepath"
 	"testing"
 
-	"github.com/mesg-foundation/core/config"
 	"github.com/mesg-foundation/core/container"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,7 +54,6 @@ func TestStartConfig(t *testing.T) {
 	require.True(t, contains(spec.Env, "MESG_MESG_PATH=/mesg"))
 	require.True(t, contains(spec.Env, "MESG_LOG_LEVEL=info"))
 	require.True(t, contains(spec.Env, "MESG_LOG_FORMAT=text"))
-	require.True(t, contains(spec.Env, "MESG_SERVICE_PATH_HOST="+filepath.Join(viper.GetString(config.MESGPath), "services")))
 	// Ensure that the port is shared
 	require.Equal(t, spec.Ports[0].Published, uint32(50052))
 	require.Equal(t, spec.Ports[0].Target, uint32(50052))
@@ -65,6 +61,6 @@ func TestStartConfig(t *testing.T) {
 	require.Equal(t, spec.Mounts[0].Source, dockerSocket)
 	require.Equal(t, spec.Mounts[0].Target, dockerSocket)
 	// Ensure that the host users folder is sync with the core
-	require.Equal(t, spec.Mounts[1].Source, viper.GetString(config.MESGPath))
-	require.Equal(t, spec.Mounts[1].Target, "/mesg")
+	require.Equal(t, spec.Mounts[1].Source, volume)
+	require.Equal(t, spec.Mounts[1].Target, path)
 }

--- a/service/start.go
+++ b/service/start.go
@@ -3,17 +3,12 @@ package service
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
 
-	"github.com/mesg-foundation/core/x/xstructhash"
-
-	"github.com/mesg-foundation/core/config"
 	"github.com/mesg-foundation/core/container"
-	"github.com/spf13/viper"
+	"github.com/mesg-foundation/core/x/xstructhash"
 )
 
 // Start starts the service.
@@ -119,16 +114,10 @@ func (dependency *DependencyFromService) extractVolumes() ([]container.Mount, er
 	if service == nil {
 		return nil, errors.New("Service is nil")
 	}
-	servicePath := strings.Join(service.namespace(), "-")
 	volumes := make([]container.Mount, 0)
 	for _, volume := range dependency.Volumes {
-		source := xstructhash.Hash([]string{
-			service.Hash(),
-			dependency.Name,
-			volume,
-		}, 1)
 		volumes = append(volumes, container.Mount{
-			Source: source,
+			Source: volumeKey(service, dependency.Name, volume),
 			Target: volume,
 		})
 	}
@@ -138,15 +127,19 @@ func (dependency *DependencyFromService) extractVolumes() ([]container.Mount, er
 			return nil, fmt.Errorf("Dependency %s do not exist", depName)
 		}
 		for _, volume := range dep.Volumes {
-			path := filepath.Join(servicePath, depName, volume)
-			source := filepath.Join(viper.GetString(config.ServicePathHost), path)
 			volumes = append(volumes, container.Mount{
-				Source: source,
+				Source: volumeKey(service, depName, volume),
 				Target: volume,
 			})
-			// TODO: move mkdir in container package
-			os.MkdirAll(filepath.Join(viper.GetString(config.ServicePathDocker), path), os.ModePerm)
 		}
 	}
 	return volumes, nil
+}
+
+func volumeKey(s *Service, dependency string, volume string) string {
+	return xstructhash.Hash([]string{
+		s.Hash(),
+		dependency,
+		volume,
+	}, 1)
 }

--- a/service/start_test.go
+++ b/service/start_test.go
@@ -200,3 +200,57 @@ func TestServiceDependenciesListensFromSamePort(t *testing.T) {
 	require.NotZero(t, err)
 	require.Contains(t, err.Error(), `port '80' is already in use`)
 }
+
+func TestExtractVolumes(t *testing.T) {
+	dep := &DependencyFromService{}
+	_, err := dep.extractVolumes()
+	require.NotNil(t, err)
+
+	dep = &DependencyFromService{
+		Name:    "test",
+		Service: &Service{},
+		Dependency: &Dependency{
+			Volumes: []string{"foo", "bar"},
+		},
+	}
+	volumes, err := dep.extractVolumes()
+	require.Nil(t, err)
+	require.Len(t, volumes, 2)
+	require.Equal(t, volumeKey(dep.Service, "test", "foo"), volumes[0].Source)
+	require.Equal(t, "foo", volumes[0].Target)
+	require.Equal(t, false, volumes[0].Bind)
+	require.Equal(t, volumeKey(dep.Service, "test", "bar"), volumes[1].Source)
+	require.Equal(t, "bar", volumes[1].Target)
+	require.Equal(t, false, volumes[1].Bind)
+
+	dep = &DependencyFromService{
+		Service: &Service{},
+		Dependency: &Dependency{
+			Volumesfrom: []string{"test"},
+		},
+	}
+	_, err = dep.extractVolumes()
+	require.NotNil(t, err)
+
+	dep = &DependencyFromService{
+		Service: &Service{
+			Dependencies: map[string]*Dependency{
+				"test": &Dependency{
+					Volumes: []string{"foo", "bar"},
+				},
+			},
+		},
+		Dependency: &Dependency{
+			Volumesfrom: []string{"test"},
+		},
+	}
+	volumes, err = dep.extractVolumes()
+	require.Nil(t, err)
+	require.Len(t, volumes, 2)
+	require.Equal(t, volumeKey(dep.Service, "test", "foo"), volumes[0].Source)
+	require.Equal(t, "foo", volumes[0].Target)
+	require.Equal(t, false, volumes[0].Bind)
+	require.Equal(t, volumeKey(dep.Service, "test", "bar"), volumes[1].Source)
+	require.Equal(t, "bar", volumes[1].Target)
+	require.Equal(t, false, volumes[1].Bind)
+}


### PR DESCRIPTION
The actual system is using binding for services volumes. In our case we don't really need to bind the folder to a specific path on the host machine and this add a lot of complexity on the configuration of this docker container.

The docker socket sent to the core container is still using the `bind` mode but other volumes are now using the new default value from docker `volume` and not `bind` anymore. This means that all the volumes that need to be mounted on a service will no longer be present in `~/.mesg/services` but will be managed by docker.

This will be helpful for the PR #416 

fix #125 