### PR TITLE
Fix PrettyJson colorize function

### DIFF
--- a/commands/service_dev.go
+++ b/commands/service_dev.go
@@ -98,15 +98,15 @@ loop:
 		case e := <-listenEventsC:
 			fmt.Printf("Receive event %s: %s\n",
 				pretty.Success(e.EventKey),
-				pretty.ColorizeJSON(pretty.FgCyan, pretty.FgMagenta, []byte(e.EventData)),
+				pretty.ColorizeJSON(pretty.FgCyan, nil, []byte(e.EventData)),
 			)
 		case err := <-eventsErrC:
 			fmt.Fprintf(os.Stderr, "%s Listening events error: %s", pretty.FailSign, err)
 		case r := <-listenResultsC:
-			fmt.Printf("Receive result %s %s with data\n%s\n",
+			fmt.Printf("Receive result %s %s: %s\n",
 				pretty.Success(r.TaskKey),
 				pretty.Colorize(color.New(color.FgCyan), r.OutputKey),
-				pretty.ColorizeJSON(pretty.FgBlue, pretty.FgMagenta, []byte(r.OutputData)),
+				pretty.ColorizeJSON(pretty.FgCyan, nil, []byte(r.OutputData)),
 			)
 		case err := <-resultsErrC:
 			fmt.Fprintf(os.Stderr, "%s Listening results error: %s", pretty.FailSign, err)

--- a/utils/pretty/pretty.go
+++ b/utils/pretty/pretty.go
@@ -210,7 +210,7 @@ func (p *Pretty) ColorizeJSON(keyColor *color.Color, valueColor *color.Color, da
 
 	var (
 		in  map[string]interface{}
-		out map[string]interface{}
+		out []string
 	)
 
 	if json.Unmarshal(data, &in) != nil {
@@ -223,17 +223,14 @@ func (p *Pretty) ColorizeJSON(keyColor *color.Color, valueColor *color.Color, da
 	if valueColor == nil {
 		valueColor = color.New()
 	}
-
-	for k, v := range in {
-		out[keyColor.Sprint(k)] = valueColor.Sprint(v)
+	for key, value := range in {
+		out = append(out, fmt.Sprintf(
+			`"%v": "%v"`,
+			keyColor.Sprint(key),
+			valueColor.Sprint(value),
+		))
 	}
-
-	b, err := json.Marshal(out)
-	if err != nil {
-		return data
-	}
-
-	return b
+	return []byte(fmt.Sprintf("{ %v }", strings.Join(out, ", ")))
 }
 
 // Progress prints spinner with the given message while calling fn function.


### PR DESCRIPTION
The PrettyJSON function was panicking because of a non initialized map.

```
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/mesg-foundation/core/utils/pretty.(*Pretty).ColorizeJSON(0xc0000ae680, 0xc0000be220, 0xc0000be200, 0xc0003c4500, 0x125, 0x140, 0x140, 0x125, 0xc0003c4500)
        /Users/nico/Developments/Go/src/github.com/mesg-foundation/core/utils/pretty/pretty.go:228 +0x2e4
github.com/mesg-foundation/core/utils/pretty.ColorizeJSON(0xc0000be220, 0xc0000be200, 0xc0003c4500, 0x125, 0x140, 0x140, 0x0, 0xc00077d280)
        /Users/nico/Developments/Go/src/github.com/mesg-foundation/core/utils/pretty/pretty.go:360 +0x63
github.com/mesg-foundation/core/commands.(*serviceDevCmd).runE(0xc0003f36e0, 0xc0000c9b00, 0xc00016eef0, 0x1, 0x1, 0x0, 0x0)
        /Users/nico/Developments/Go/src/github.com/mesg-foundation/core/commands/service_dev.go:98 +0xc85
github.com/mesg-foundation/core/commands.(*serviceDevCmd).runE-fm(0xc0000c9b00, 0xc00016eef0, 0x1, 0x1, 0x0, 0x0)
        /Users/nico/Developments/Go/src/github.com/mesg-foundation/core/commands/service_dev.go:37 +0x52
github.com/mesg-foundation/core/vendor/github.com/spf13/cobra.(*Command).execute(0xc0000c9b00, 0xc00016eec0, 0x1, 0x1, 0xc0000c9b00, 0xc00016eec0)
        /Users/nico/Developments/Go/src/github.com/mesg-foundation/core/vendor/github.com/spf13/cobra/command.go:746 +0x473
github.com/mesg-foundation/core/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc00043efc0, 0x3, 0xc0001aaae0, 0xf)
        /Users/nico/Developments/Go/src/github.com/mesg-foundation/core/vendor/github.com/spf13/cobra/command.go:831 +0x2dc
github.com/mesg-foundation/core/vendor/github.com/spf13/cobra.(*Command).Execute(0xc00043efc0, 0x18d6271, 0x9)
        /Users/nico/Developments/Go/src/github.com/mesg-foundation/core/vendor/github.com/spf13/cobra/command.go:784 +0x2b
main.main()
        /Users/nico/Developments/Go/src/github.com/mesg-foundation/core/interface/cli/main.go:35 +0x25b
exit status 2
```