### PR TITLE
Improve database error handling

### DIFF
--- a/database/services/all.go
+++ b/database/services/all.go
@@ -1,8 +1,6 @@
 package services
 
 import (
-	"encoding/json"
-
 	"github.com/mesg-foundation/core/service"
 )
 
@@ -16,9 +14,9 @@ func All() ([]*service.Service, error) {
 	var services []*service.Service
 	iter := db.NewIterator(nil, nil)
 	for iter.Next() {
-		var service service.Service
-		if err := json.Unmarshal(iter.Value(), &service); err != nil {
 			return nil, err
+		service, err := decode(string(iter.Key()), iter.Value())
+		if err != nil {
 		}
 		services = append(services, &service)
 	}

--- a/database/services/all.go
+++ b/database/services/all.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"github.com/mesg-foundation/core/service"
+	"github.com/sirupsen/logrus"
 )
 
 // All returns all deployed services.
@@ -14,11 +15,17 @@ func All() ([]*service.Service, error) {
 	var services []*service.Service
 	iter := db.NewIterator(nil, nil)
 	for iter.Next() {
-			return nil, err
 		service, err := decode(string(iter.Key()), iter.Value())
 		if err != nil {
+			// Ignore all decode errors (possibly due to a service structure change or database corruption)
+			if decodeErr, ok := err.(*DecodeError); ok {
+				logrus.WithField("service", decodeErr.Hash).Warning(decodeErr.Error())
+			} else {
+				return nil, err
+			}
+		} else {
+			services = append(services, service)
 		}
-		services = append(services, &service)
 	}
 	iter.Release()
 	return services, iter.Error()

--- a/database/services/encode.go
+++ b/database/services/encode.go
@@ -1,0 +1,21 @@
+package services
+
+import (
+	"encoding/json"
+
+	"github.com/mesg-foundation/core/service"
+)
+
+// encode returns the marshaled version of the service
+func encode(service *service.Service) ([]byte, error) {
+	return json.Marshal(service)
+}
+
+// decode decodes the data and return an DecodeError if not possible
+func decode(hash string, data []byte) (*service.Service, error) {
+	s := &service.Service{}
+	if err := json.Unmarshal(data, s); err != nil {
+		return nil, &DecodeError{Hash: hash}
+	}
+	return s, nil
+}

--- a/database/services/encode_test.go
+++ b/database/services/encode_test.go
@@ -1,0 +1,14 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeError(t *testing.T) {
+	hash := "IDToTest"
+	_, err := decode(hash, []byte("oaiwdhhiodoihwaiohwa"))
+	require.Error(t, err)
+	require.IsType(t, &DecodeError{}, err)
+}

--- a/database/services/errors.go
+++ b/database/services/errors.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"fmt"
+
 	leveldbErrors "github.com/syndtr/goleveldb/leveldb/errors"
 )
 
@@ -10,7 +12,7 @@ type NotFound struct {
 }
 
 func (e NotFound) Error() string {
-	return "Database services: Service with hash '" + e.Hash + "' not found"
+	return fmt.Sprintf("Database services: Service %q not found", e.Hash)
 }
 
 func handleErrorNotFound(err error, hash string) error {
@@ -18,4 +20,13 @@ func handleErrorNotFound(err error, hash string) error {
 		return NotFound{Hash: hash}
 	}
 	return err
+}
+
+// DecodeError represents a service impossible to decode
+type DecodeError struct {
+	Hash string
+}
+
+func (e *DecodeError) Error() string {
+	return fmt.Sprintf("Database services: Could not decode service %q.", e.Hash)
 }

--- a/database/services/get.go
+++ b/database/services/get.go
@@ -1,8 +1,6 @@
 package services
 
 import (
-	"encoding/json"
-
 	"github.com/mesg-foundation/core/service"
 )
 
@@ -18,6 +16,5 @@ func Get(id string) (*service.Service, error) {
 		err = handleErrorNotFound(err, id)
 		return nil, err
 	}
-	s := &service.Service{}
-	return s, json.Unmarshal(bytes, s)
+	return decode(id, bytes)
 }

--- a/database/services/save.go
+++ b/database/services/save.go
@@ -1,14 +1,12 @@
 package services
 
 import (
-	"encoding/json"
-
 	"github.com/mesg-foundation/core/service"
 )
 
 // Save stores a service in the database.
 func Save(service *service.Service) error {
-	bytes, err := json.Marshal(service)
+	bytes, err := encode(service)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR improve the handling of database error.
The reason is we cannot decode Service from v1.1 because we changed their structure.

In order to not break the application, the function database.services.All output the decode error rather than returning it.
The unmarshal error has been improved by the DecodeError with a nicer message.