### PR TITLE
Add multiline option to Pretty.ColorizeJSON

### DIFF
--- a/commands/service_dev.go
+++ b/commands/service_dev.go
@@ -95,7 +95,7 @@ loop:
 		case e := <-listenEventsC:
 			fmt.Printf("Receive event %s: %s\n",
 				pretty.Success(e.EventKey),
-				pretty.ColorizeJSON(pretty.FgCyan, nil, []byte(e.EventData)),
+				pretty.ColorizeJSON(pretty.FgCyan, nil, false, []byte(e.EventData)),
 			)
 		case err := <-eventsErrC:
 			fmt.Fprintf(os.Stderr, "%s Listening events error: %s", pretty.FailSign, err)
@@ -103,7 +103,7 @@ loop:
 			fmt.Printf("Receive result %s %s: %s\n",
 				pretty.Success(r.TaskKey),
 				pretty.Colorize(color.New(color.FgCyan), r.OutputKey),
-				pretty.ColorizeJSON(pretty.FgCyan, nil, []byte(r.OutputData)),
+				pretty.ColorizeJSON(pretty.FgCyan, nil, false, []byte(r.OutputData)),
 			)
 		case err := <-resultsErrC:
 			fmt.Fprintf(os.Stderr, "%s Listening results error: %s", pretty.FailSign, err)

--- a/utils/pretty/pretty.go
+++ b/utils/pretty/pretty.go
@@ -215,7 +215,7 @@ func (p *Pretty) ColorizeJSON(keyColor *color.Color, valueColor *color.Color, mu
 	}
 
 	f := prettyjson.NewFormatter()
-	if false == multiline {
+	if !multiline {
 		f.Indent = 0
 		f.Newline = ""
 	}

--- a/utils/pretty/pretty.go
+++ b/utils/pretty/pretty.go
@@ -209,14 +209,16 @@ func (p *Pretty) Colorize(c *color.Color, msg string) string {
 
 // ColorizeJSON colors keys and values of stringified JSON. On errors the original string is returned.
 // If color is nil then key/value won't be colorize.
-func (p *Pretty) ColorizeJSON(keyColor *color.Color, valueColor *color.Color, data []byte) []byte {
+func (p *Pretty) ColorizeJSON(keyColor *color.Color, valueColor *color.Color, multiline bool, data []byte) []byte {
 	if p.noColor {
 		return data
 	}
 
 	f := prettyjson.NewFormatter()
-	f.Indent = 0
-	f.Newline = ""
+	if multiline == false {
+		f.Indent = 0
+		f.Newline = ""
+	}
 
 	f.KeyColor = keyColor
 	f.StringColor = valueColor
@@ -358,8 +360,8 @@ func Progress(message string, fn func()) { pg.Progress(message, fn) }
 
 // ColorizeJSON colors keys and values of stringified JSON. On errors the original string is returned.
 // If color is nil then key/value won't be colorize.
-func ColorizeJSON(keyColor *color.Color, valueColor *color.Color, data []byte) []byte {
-	return pg.ColorizeJSON(keyColor, valueColor, data)
+func ColorizeJSON(keyColor *color.Color, valueColor *color.Color, multiline bool, data []byte) []byte {
+	return pg.ColorizeJSON(keyColor, valueColor, multiline, data)
 }
 
 // FgColors returns a slice with predefiend foreground color.

--- a/utils/pretty/pretty.go
+++ b/utils/pretty/pretty.go
@@ -215,7 +215,7 @@ func (p *Pretty) ColorizeJSON(keyColor *color.Color, valueColor *color.Color, mu
 	}
 
 	f := prettyjson.NewFormatter()
-	if multiline == false {
+	if false == multiline {
 		f.Indent = 0
 		f.Newline = ""
 	}


### PR DESCRIPTION
Very simple PR to add the multiline option to Pretty.ColorizeJSON function.
It is useful for a following PR.