### PR TITLE
fix issue when passing wrong arguments

### DIFF
--- a/commands/service_execute.go
+++ b/commands/service_execute.go
@@ -66,7 +66,8 @@ func (c *serviceExecuteCmd) runE(cmd *cobra.Command, args []string) error {
 			return
 		}
 
-		inputData, err := c.getData(c.taskKey, s, c.executeData)
+		var inputData string
+		inputData, err = c.getData(c.taskKey, s, c.executeData)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Saw one small bug when executing a service with the wrong parameters, we didn't exit the loop and were waiting indefinitely because the error was re-declare inside the loading