### PR TITLE
Fix: Add network aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,101 +1,139 @@
 # Changelog
 
-## [Unreleased]
+## [Unreleased](https://github.com/mesg-foundation/core/releases/tag/)
+
+#### Added
 #### Changed
-- (#435) `service logs` and `service dev` commands now outputs colored dependency logs.
-- (#435) `service logs` accepts multiple dependency filters with multiple use of `-d` flag.
+#### Added
+#### Removed
+
+## [v0.3.0](https://github.com/mesg-foundation/core/releases/tag/v0.3.0)
 
 #### Added
 
-- (#) Support of `.dockerignore` file
+- ([#392](https://github.com/mesg-foundation/core/pull/392)) **BREAKING CHANGE.** Add support for `.dockerignore`. Remove support of `.mesgignore` [#498](https://github.com/mesg-foundation/core/pull/498).
+- ([#383](https://github.com/mesg-foundation/core/pull/383)) New API package. [#386](https://github.com/mesg-foundation/core/pull/386). [#444](https://github.com/mesg-foundation/core/pull/444). [#486](https://github.com/mesg-foundation/core/pull/486). [#488](https://github.com/mesg-foundation/core/pull/488).
+- ([#409](https://github.com/mesg-foundation/core/pull/409)) Add required validations on service's task, event and output data.
+- ([#432](https://github.com/mesg-foundation/core/pull/432)) Configuration of the CLI's output with `--no-color` and `--no-spinner` flags. Colorize JSON. [#453](https://github.com/mesg-foundation/core/pull/453). [#480](https://github.com/mesg-foundation/core/pull/480). [#484](https://github.com/mesg-foundation/core/pull/484).
+- ([#435](https://github.com/mesg-foundation/core/pull/435)) Command `service logs` accepts multiple dependency filters with multiple use of `-d` flag.
+- ([#478](https://github.com/mesg-foundation/core/pull/478)) Allow multiple core to run on the same computer.
+- ([#493](https://github.com/mesg-foundation/core/pull/493)) Support numbers in service task's key, event's key and output's key
+- ([#499](https://github.com/mesg-foundation/core/pull/499)) Return service's status from API
 
-#### Removed
+#### Changed
+
+- ([#371](https://github.com/mesg-foundation/core/pull/371)) Delegate deployment of Service to Core. [#469](https://github.com/mesg-foundation/core/pull/469).
+- ([#404](https://github.com/mesg-foundation/core/pull/404)) Change building tool.
+- ([#413](https://github.com/mesg-foundation/core/pull/413)) Improve command `service dev`. [#459](https://github.com/mesg-foundation/core/pull/459).
+- ([#417](https://github.com/mesg-foundation/core/pull/417)) Service refactoring. [#402](https://github.com/mesg-foundation/core/pull/402). [#414](https://github.com/mesg-foundation/core/pull/414). [#454](https://github.com/mesg-foundation/core/pull/454). [#458](https://github.com/mesg-foundation/core/pull/458). [#464](https://github.com/mesg-foundation/core/pull/464). [#472](https://github.com/mesg-foundation/core/pull/472). [#490](https://github.com/mesg-foundation/core/pull/490). [#491](https://github.com/mesg-foundation/core/pull/491).
+- ([#419](https://github.com/mesg-foundation/core/pull/419)) Use Docker volumes for services. [#477](https://github.com/mesg-foundation/core/pull/477).
+- ([#427](https://github.com/mesg-foundation/core/pull/427)) Refactor package Config
+- ([#481](https://github.com/mesg-foundation/core/pull/481)) Refactor package Database
+- ([#485](https://github.com/mesg-foundation/core/pull/485)) Improve CLI output. [#521](https://github.com/mesg-foundation/core/pull/521).
+- Tests improvements. [#381](https://github.com/mesg-foundation/core/pull/381). [#384](https://github.com/mesg-foundation/core/pull/384). [#391](https://github.com/mesg-foundation/core/pull/391). [#446](https://github.com/mesg-foundation/core/pull/446). [#447](https://github.com/mesg-foundation/core/pull/447). [#466](https://github.com/mesg-foundation/core/pull/466). [#489](https://github.com/mesg-foundation/core/pull/489). [#501](https://github.com/mesg-foundation/core/pull/501). [#504](https://github.com/mesg-foundation/core/pull/504). [#506](https://github.com/mesg-foundation/core/pull/506).
+
 #### Fixed
 
-## [v1.1.0]
-
-#### Changed
-- (#282) Branch support added. You can now specify your branches with a `#branch` fragment at the end of your git url. E.g.: https://github.com/mesg-foundation/service-ethereum-erc20#websocket
-- (#299) Add more user friendly errors when failing to connect to the Core or Docker
-- (#356) Use github.com/stretchr/testify package
-- (#352) Use logrus logging package
-
-#### Added
-- (#242) Add more details in command `mesg-core service validate`
-- (#295) Added more validation on the API for the data of `executeTask`, `submitResult` and `emitEvent`. Now if data doesn't match the service file, the API returns an error
-- (#302) Possibility to use a config file in ~/.mesg/config.yml
-- (#303) Add command `service dev` that build and run the service with the logs
-- (#303) Add command `service execute` that execute a task on a service
-- (#316) Delete service when stoping the `service dev` command to avoid to keep all the versions of the services.
-- (#317) Add errors when trying to execute a service that is not running (nothing was happening before)
-- (#344) Add `service execute --data` flag to pass arguments as key=value.
-- (#362) Add `tags` list parameter for execution in order to be able to categorize and/or track a specific task execution.
-- (#362) Add possibility to listen to results with the specific tag(s)
-
-#### Removed
-- (#303) Deprecate command `service test` in favor of `service dev` and `service execute`
-
-#### Fixed
-- (#358) Fix goroutine leaks on api package handlers where gRPC streams are used. Handlers now doesn't block forever by exiting on context cancellation and stream.Send() errors.
-
-## [v1.0.0]
-
-#### Changed
-- (#247) Update the `service init` command to have initial tasks and events
-- (#257) Update the `service init` command to fetch for template based on the https://github.com/mesg-foundation/awesome/blob/master/templates.json file but also custom templates by giving the address of the template
-- (#261) **BREAKING** More consistancy between the APIs, rename `taskData` into `inputData` for the `executeTask` API
-
-#### Added
-- (#267) Add Command `service gen-doc` that generate a `README.md` in the service based on the informations of the `mesg.yml`
-- (#246) Add .mesgignore to excluding file from the Docker build
+- ([#401](https://github.com/mesg-foundation/core/pull/401)) Gracefully stop gRPC servers.
+- ([#429](https://github.com/mesg-foundation/core/pull/429)) Fix issue when stopping services. [#505](https://github.com/mesg-foundation/core/pull/505). [#526](https://github.com/mesg-foundation/core/pull/526).
+- ([#476](https://github.com/mesg-foundation/core/pull/476)) Improve database error handling.
+- ([#482](https://github.com/mesg-foundation/core/pull/482)) Fix Service hash changed when fetching from git.
 
 #### Removed
 
-#### Fixed
-- (#246) Ignore files during Docker build
+- ([#410](https://github.com/mesg-foundation/core/pull/410)) Remove socket server in favor of the TCP server.
 
-## [v1.0.0-beta2]
+#### Documentation
 
-#### Changed
-- (#247) Update the `service init` command to have initial tasks and events
-- (#257) Update the `service init` command to fetch for template based on the https://github.com/mesg-foundation/awesome/blob/master/templates.json file but also custom templates by giving the address of the template
-- (#261) **BREAKING** More consistancy between the APIs, rename `taskData` into `inputData` for the `executeTask` API
+- ([#415](https://github.com/mesg-foundation/core/pull/415)) Added hall-of-fame to README. Thanks [sergey48k](https://github.com/sergey48k).
+- ([#423](https://github.com/mesg-foundation/core/pull/423)) Fix documentation issue.
+- ([#474](https://github.com/mesg-foundation/core/pull/474)) Documentation/update ux.
+- ([#509](https://github.com/mesg-foundation/core/pull/509)) Add forum link. [#513](https://github.com/mesg-foundation/core/pull/513).
+- ([#510](https://github.com/mesg-foundation/core/pull/510)) Update ecosystem menu.
+- ([#511](https://github.com/mesg-foundation/core/pull/511)) Update tutorial page.
+- ([#512](https://github.com/mesg-foundation/core/pull/512)) Add sitemap.
+
+## [v0.2.0](https://github.com/mesg-foundation/core/releases/tag/v0.2.0)
 
 #### Added
-- (#246) Add .mesgignore to excluding file from the Docker build
+- ([#242](https://github.com/mesg-foundation/core/pull/242)) Add more details in command `mesg-core service validate`
+- ([#295](https://github.com/mesg-foundation/core/pull/295)) Added more validation on the API for the data of `executeTask`, `submitResult` and `emitEvent`. Now if data doesn't match the service file, the API returns an error
+- ([#302](https://github.com/mesg-foundation/core/pull/302)) Possibility to use a config file in ~/.mesg/config.yml
+- ([#303](https://github.com/mesg-foundation/core/pull/303)) Add command `service dev` that build and run the service with the logs
+- ([#303](https://github.com/mesg-foundation/core/pull/303)) Add command `service execute` that execute a task on a service
+- ([#316](https://github.com/mesg-foundation/core/pull/316)) Delete service when stoping the `service dev` command to avoid to keep all the versions of the services.
+- ([#317](https://github.com/mesg-foundation/core/pull/317)) Add errors when trying to execute a service that is not running (nothing was happening before)
+- ([#344](https://github.com/mesg-foundation/core/pull/344)) Add `service execute --data` flag to pass arguments as key=value.
+- ([#362](https://github.com/mesg-foundation/core/pull/362)) Add `tags` list parameter for execution in order to be able to categorize and/or track a specific task execution.
+- ([#362](https://github.com/mesg-foundation/core/pull/362)) Add possibility to listen to results with the specific tag(s)
+
+#### Changed
+- ([#282](https://github.com/mesg-foundation/core/pull/282)) Branch support added. You can now specify your branches with a `#branch` fragment at the end of your git url. E.g.: https://github.com/mesg-foundation/service-ethereum-erc20#websocket
+- ([#299](https://github.com/mesg-foundation/core/pull/299)) Add more user friendly errors when failing to connect to the Core or Docker
+- ([#356](https://github.com/mesg-foundation/core/pull/356)) Use github.com/stretchr/testify package
+- ([#352](https://github.com/mesg-foundation/core/pull/352)) Use logrus logging package
+
+#### Fixed
+- ([#358](https://github.com/mesg-foundation/core/pull/358)) Fix goroutine leaks on api package handlers where gRPC streams are used. Handlers now doesn't block forever by exiting on context cancellation and stream.Send() errors.
 
 #### Removed
+- ([#303](https://github.com/mesg-foundation/core/pull/303)) Deprecate command `service test` in favor of `service dev` and `service execute`
 
-#### Fixed
-- (#246) Ignore files during Docker build
-
-## [v1.0.0-beta]
-
-#### Changed
-- (#174) Update CI to build version based on tags
-- (#173) Use official Docker client
-- (#175) Changed the struct to use to start docker service
-- (#181) MESG Core and Service start and stop functions wait for the docker container to actually run or stop.
-- (#183) **BREAKING** Docker image is automatically injected in the `mesg.yml` file for your service. Now `dependencies` attribute is for extra dependencies so for most of service this is not necessary anymore.
-- (#212) **BREAKING** Communication from services to core is now done through a token provided by the core
-- (#236) CLI only use the API
-- (#234) `service list` command now includes the status for every services
+## [v0.1.0](https://github.com/mesg-foundation/core/releases/tag/v0.1.0)
 
 #### Added
-- (#174) Add CHANGELOG.md file
-- (#179) Add filters for the core API
+- ([#267](https://github.com/mesg-foundation/core/pull/267)) Add Command `service gen-doc` that generate a `README.md` in the service based on the informations of the `mesg.yml`
+- ([#246](https://github.com/mesg-foundation/core/pull/246)) Add .mesgignore to excluding file from the Docker build
+
+#### Changed
+- ([#247](https://github.com/mesg-foundation/core/pull/247)) Update the `service init` command to have initial tasks and events
+- ([#257](https://github.com/mesg-foundation/core/pull/257)) Update the `service init` command to fetch for template based on the https://github.com/mesg-foundation/awesome/blob/master/templates.json file but also custom templates by giving the address of the template
+- ([#261](https://github.com/mesg-foundation/core/pull/261)) **BREAKING** More consistancy between the APIs, rename `taskData` into `inputData` for the `executeTask` API
+
+#### Fixed
+- ([#246](https://github.com/mesg-foundation/core/pull/246)) Ignore files during Docker build
+
+## [v0.1.0-beta3](https://github.com/mesg-foundation/core/releases/tag/v0.1.0-beta3)
+
+#### Added
+- ([#246](https://github.com/mesg-foundation/core/pull/246)) Add .mesgignore to excluding file from the Docker build
+
+#### Changed
+- ([#247](https://github.com/mesg-foundation/core/pull/247)) Update the `service init` command to have initial tasks and events
+- ([#257](https://github.com/mesg-foundation/core/pull/257)) Update the `service init` command to fetch for template based on the https://github.com/mesg-foundation/awesome/blob/master/templates.json file but also custom templates by giving the address of the template
+- ([#261](https://github.com/mesg-foundation/core/pull/261)) **BREAKING** More consistancy between the APIs, rename `taskData` into `inputData` for the `executeTask` API
+
+#### Fixed
+- ([#246](https://github.com/mesg-foundation/core/pull/246)) Ignore files during Docker build
+
+## [v0.1.0-beta2](https://github.com/mesg-foundation/core/releases/tag/v0.1.0-beta2)
+
+#### Added
+- ([#174](https://github.com/mesg-foundation/core/pull/174)) Add CHANGELOG.md file
+- ([#179](https://github.com/mesg-foundation/core/pull/179)) Add filters for the core API
   - [API] Add `eventFilter` on `ListenEvent` API to get notification when an event with a specific name occurs
   - [API] Add `taskFilter` on `ListenResult` API to get notification when a result from a specific task occurs
   - [API] Add `outputFilter` on `ListenResult` API to get notification when a result returns a specific output
-- (#183) Add a `configuration` attribute in the `mesg.yml` file to accept docker configuration for your service
-- (#187) Stop all services when the MESG Core stops
-- (#190) Possibility to `test` or `deploy` a service from a git or GitHub url
-- (#233) Add logs in the `service test` command with service logs by default and all dependencies logs with the `--full-logs` flag
-- (#235) Add `ListServices` and `GetService` APIs
+- ([#183](https://github.com/mesg-foundation/core/pull/183)) Add a `configuration` attribute in the `mesg.yml` file to accept docker configuration for your service
+- ([#187](https://github.com/mesg-foundation/core/pull/187)) Stop all services when the MESG Core stops
+- ([#190](https://github.com/mesg-foundation/core/pull/190)) Possibility to `test` or `deploy` a service from a git or GitHub url
+- ([#233](https://github.com/mesg-foundation/core/pull/233)) Add logs in the `service test` command with service logs by default and all dependencies logs with the `--full-logs` flag
+- ([#235](https://github.com/mesg-foundation/core/pull/235)) Add `ListServices` and `GetService` APIs
 
-#### Removed
-- (#234) Remove command `service status` in favor of `service list` command that includes status
+#### Changed
+- ([#174](https://github.com/mesg-foundation/core/pull/174)) Update CI to build version based on tags
+- ([#173](https://github.com/mesg-foundation/core/pull/173)) Use official Docker client
+- ([#175](https://github.com/mesg-foundation/core/pull/175)) Changed the struct to use to start docker service
+- ([#181](https://github.com/mesg-foundation/core/pull/181)) MESG Core and Service start and stop functions wait for the docker container to actually run or stop.
+- ([#183](https://github.com/mesg-foundation/core/pull/183)) **BREAKING** Docker image is automatically injected in the `mesg.yml` file for your service. Now `dependencies` attribute is for extra dependencies so for most of service this is not necessary anymore.
+- ([#212](https://github.com/mesg-foundation/core/pull/212)) **BREAKING** Communication from services to core is now done through a token provided by the core
+- ([#236](https://github.com/mesg-foundation/core/pull/236)) CLI only use the API
+- ([#234](https://github.com/mesg-foundation/core/pull/234)) `service list` command now includes the status for every services
 
 #### Fixed
-- (#179) [Doc] Outdated documentation for the CLI
-- (#185) Fix logs with extra characters when `mesg-core logs`
+- ([#179](https://github.com/mesg-foundation/core/pull/179)) [Doc] Outdated documentation for the CLI
+- ([#185](https://github.com/mesg-foundation/core/pull/185)) Fix logs with extra characters when `mesg-core logs`
+
+
+#### Removed
+- ([#234](https://github.com/mesg-foundation/core/pull/234)) Remove command `service status` in favor of `service list` command that includes status

--- a/container/service_options.go
+++ b/container/service_options.go
@@ -97,11 +97,15 @@ func (options *ServiceOptions) swarmMounts(force bool) []mount.Mount {
 	return mounts
 }
 
+// swarmNetworks creates all necessary network attachment configurations
+// Each network will be attached based on their networkID but also based on aliases
+// These aliases will make services accessible from other containers inside the same network
 func (options *ServiceOptions) swarmNetworks() (networks []swarm.NetworkAttachmentConfig) {
 	networks = make([]swarm.NetworkAttachmentConfig, len(options.NetworksID))
 	for i, networkID := range options.NetworksID {
 		networks[i] = swarm.NetworkAttachmentConfig{
-			Target: networkID,
+			Target:  networkID,
+			Aliases: options.Namespace,
 		}
 	}
 	return

--- a/container/service_options.go
+++ b/container/service_options.go
@@ -22,10 +22,14 @@ type ServiceOptions struct {
 	Labels    map[string]string
 }
 
-// Network contains an ID of a docker network and it's associated optional alias
+// Network contains an ID of a docker network and it's associated optional alias.
 type Network struct {
-	ID    string // ID of the docker network
-	Alias string // Alias is an optional attribute to name this network and be able to access it using this name
+	// ID of the docker network.
+	ID string
+
+	// Alias is an optional attribute to name this service in the
+	// network and be able to access it using this name.
+	Alias string
 }
 
 // Port is a simplify version of swarm.PortConfig.
@@ -103,9 +107,10 @@ func (options *ServiceOptions) swarmMounts(force bool) []mount.Mount {
 	return mounts
 }
 
-// swarmNetworks creates all necessary network attachment configurations
-// Each network will be attached based on their networkID but also based on aliases
-// These aliases will make services accessible from other containers inside the same network
+// swarmNetworks creates all necessary network attachment configurations for service.
+// each network will be attached based on their networkID and an alias can be used to
+// identify service in the network.
+// aliases will make services accessible from other containers inside the same network.
 func (options *ServiceOptions) swarmNetworks() (networks []swarm.NetworkAttachmentConfig) {
 	networks = make([]swarm.NetworkAttachmentConfig, len(options.Networks))
 	for i, network := range options.Networks {
@@ -117,7 +122,7 @@ func (options *ServiceOptions) swarmNetworks() (networks []swarm.NetworkAttachme
 		}
 		networks[i] = cfg
 	}
-	return
+	return networks
 }
 
 func mergeLabels(l1 map[string]string, l2 map[string]string) map[string]string {

--- a/container/service_options.go
+++ b/container/service_options.go
@@ -12,14 +12,20 @@ import (
 
 // ServiceOptions is a simplify version of swarm.ServiceSpec.
 type ServiceOptions struct {
-	Image      string
-	Namespace  []string
-	Ports      []Port
-	Mounts     []Mount
-	Env        []string // TODO: should be transform to  map[string]string and use the func mapToEnv
-	Args       []string
-	NetworksID []string
-	Labels     map[string]string
+	Image     string
+	Namespace []string
+	Ports     []Port
+	Mounts    []Mount
+	Env       []string // TODO: should be transform to  map[string]string and use the func mapToEnv
+	Args      []string
+	Networks  []Network
+	Labels    map[string]string
+}
+
+// Network contains an ID of a docker network and it's associated optional alias
+type Network struct {
+	ID    string // ID of the docker network
+	Alias string // Alias is an optional attribute to name this network and be able to access it using this name
 }
 
 // Port is a simplify version of swarm.PortConfig.
@@ -101,11 +107,15 @@ func (options *ServiceOptions) swarmMounts(force bool) []mount.Mount {
 // Each network will be attached based on their networkID but also based on aliases
 // These aliases will make services accessible from other containers inside the same network
 func (options *ServiceOptions) swarmNetworks() (networks []swarm.NetworkAttachmentConfig) {
-	networks = make([]swarm.NetworkAttachmentConfig, len(options.NetworksID))
-	for i, networkID := range options.NetworksID {
+	networks = make([]swarm.NetworkAttachmentConfig, len(options.Networks))
+	for i, network := range options.Networks {
+		aliases := make([]string, 0)
+		if network.Alias != "" {
+			aliases = append(aliases, network.Alias)
+		}
 		networks[i] = swarm.NetworkAttachmentConfig{
-			Target:  networkID,
-			Aliases: options.Namespace,
+			Target:  network.ID,
+			Aliases: aliases,
 		}
 	}
 	return

--- a/container/service_options.go
+++ b/container/service_options.go
@@ -109,14 +109,13 @@ func (options *ServiceOptions) swarmMounts(force bool) []mount.Mount {
 func (options *ServiceOptions) swarmNetworks() (networks []swarm.NetworkAttachmentConfig) {
 	networks = make([]swarm.NetworkAttachmentConfig, len(options.Networks))
 	for i, network := range options.Networks {
-		aliases := make([]string, 0)
+		cfg := swarm.NetworkAttachmentConfig{
+			Target: network.ID,
+		}
 		if network.Alias != "" {
-			aliases = append(aliases, network.Alias)
+			cfg.Aliases = []string{network.Alias}
 		}
-		networks[i] = swarm.NetworkAttachmentConfig{
-			Target:  network.ID,
-			Aliases: aliases,
-		}
+		networks[i] = cfg
 	}
 	return
 }

--- a/container/service_options.go
+++ b/container/service_options.go
@@ -22,13 +22,13 @@ type ServiceOptions struct {
 	Labels    map[string]string
 }
 
-// Network contains an ID of a docker network and it's associated optional alias.
+// Network keeps the network info for service.
 type Network struct {
 	// ID of the docker network.
 	ID string
 
 	// Alias is an optional attribute to name this service in the
-	// network and be able to access it using this name.
+	// network and be able to access to it using this name.
 	Alias string
 }
 

--- a/container/service_options_test.go
+++ b/container/service_options_test.go
@@ -110,12 +110,18 @@ func TestServiceOptionEnv(t *testing.T) {
 
 func TestServiceOptionNetworks(t *testing.T) {
 	options := &ServiceOptions{
-		NetworksID: []string{"network1", "network2"},
+		Networks: []Network{
+			Network{ID: "network1"},
+			Network{ID: "network2", Alias: "test"},
+		},
 	}
 	networks := options.swarmNetworks()
 	require.Equal(t, 2, len(networks))
 	require.Equal(t, "network1", networks[0].Target)
+	require.Equal(t, 0, len(networks[0].Aliases))
 	require.Equal(t, "network2", networks[1].Target)
+	require.Equal(t, 1, len(networks[1].Aliases))
+	require.Equal(t, "test", networks[1].Aliases[0])
 }
 
 func contains(list []string, item string) bool {

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -54,6 +54,8 @@ func serviceSpec() (spec container.ServiceOptions, err error) {
 				Published: uint32(port),
 			},
 		},
-		NetworksID: []string{sharedNetworkID},
+		Networks: []container.Network{
+			{ID: sharedNetworkID},
+		},
 	}, nil
 }

--- a/daemon/start_test.go
+++ b/daemon/start_test.go
@@ -23,9 +23,9 @@ func startForTest() {
 		panic(err)
 	}
 	_, err = defaultContainer.StartService(container.ServiceOptions{
-		Namespace:  []string{},
-		Image:      "http-server",
-		NetworksID: []string{sharedNetworkID},
+		Namespace: []string{},
+		Image:     "http-server",
+		Networks:  []container.Network{{ID: sharedNetworkID}},
 	})
 	if err != nil {
 		panic(err)

--- a/docs/guide/service/dockerize-the-service.md
+++ b/docs/guide/service/dockerize-the-service.md
@@ -89,7 +89,7 @@ dependencies:
       - "1234"
 ```
 
-Each dependency's key is used as their **hostname** on the shared network between the service and dependencies.
+Each dependency's key is used as its **hostname** on the shared network between the service and dependencies.
 In this example, the service can access the dependency at the endpoint `serviceToConnectWith:1234`.
 
 ::: tip Get Help

--- a/docs/guide/service/dockerize-the-service.md
+++ b/docs/guide/service/dockerize-the-service.md
@@ -89,8 +89,8 @@ dependencies:
       - "1234"
 ```
 
-Keys of your dependencies are used as **hostname** to access from your service.
-In this example you can access your dependency calling the `http://serviceToConnectWith:1234` endpoint.
+Each dependency's key is used as their **hostname** on the shared network between the service and dependencies.
+In this example, the service can access the dependency at the endpoint `serviceToConnectWith:1234`.
 
 ::: tip Get Help
 You need help ? Check out the <a href="https://forum.mesg.com" target="_blank">MESG Forum</a>.

--- a/docs/guide/service/dockerize-the-service.md
+++ b/docs/guide/service/dockerize-the-service.md
@@ -89,5 +89,8 @@ dependencies:
       - "1234"
 ```
 
+Keys of your dependencies are used as **hostname** to access from your service.
+In this example you can access your dependency calling the `http://serviceToConnectWith:1234` endpoint.
+
 ::: tip Get Help
 You need help ? Check out the <a href="https://forum.mesg.com" target="_blank">MESG Forum</a>.

--- a/service/start.go
+++ b/service/start.go
@@ -85,9 +85,12 @@ func (d *Dependency) Start(networkID string) (containerServiceID string, err err
 			"MESG_ENDPOINT":     endpoint,
 			"MESG_ENDPOINT_TCP": endpoint,
 		}),
-		Mounts:     mounts,
-		Ports:      d.extractPorts(),
-		NetworksID: []string{networkID, sharedNetworkID},
+		Mounts: mounts,
+		Ports:  d.extractPorts(),
+		Networks: []container.Network{
+			{ID: networkID, Alias: d.Key},
+			{ID: sharedNetworkID},
+		},
 	})
 }
 

--- a/service/start_test.go
+++ b/service/start_test.go
@@ -318,8 +318,11 @@ func mockStartService(d *Dependency, mc *mocks.Container,
 			"MESG_ENDPOINT":     endpoint,
 			"MESG_ENDPOINT_TCP": endpoint,
 		}),
-		Mounts:     mounts,
-		Ports:      d.extractPorts(),
-		NetworksID: []string{networkID, sharedNetworkID},
+		Mounts: mounts,
+		Ports:  d.extractPorts(),
+		Networks: []container.Network{
+			{ID: networkID, Alias: d.Key},
+			{ID: sharedNetworkID},
+		},
 	}).Once().Return(containerServiceID, err)
 }


### PR DESCRIPTION
Fix issue of containers from the same service that couldn't communicate with each others by adding the namespace as aliases for the network.

Now if we have the following mesg.yml
```yml
name: "serviceX"
dependencies:
  depA:
    ports:
      - "1234"
  depB:
    ports:
      - "5678"
```
We will be able to access `depA` server through `http://depA:1234` and `depB` with `http://depB:5678` but also with the service ID but this one is not really important and especially hard to do so I don't think we should document this part.

fix #533