### PR TITLE
Remove executed executions from memory

### DIFF
--- a/execution/complete.go
+++ b/execution/complete.go
@@ -24,7 +24,7 @@ func (execution *Execution) Complete(outputKey string, outputData map[string]int
 		return err
 	}
 
-	if err := execution.moveFromInProgressToProcessed(); err != nil {
+	if err := execution.deleteFromQueue(); err != nil {
 		return err
 	}
 	execution.ExecutionDuration = time.Since(execution.ExecutedAt)

--- a/execution/state.go
+++ b/execution/state.go
@@ -7,7 +7,6 @@ import (
 var mu sync.Mutex
 var pendingExecutions = make(map[string]*Execution)
 var inProgressExecutions = make(map[string]*Execution)
-var processedExecutions = make(map[string]*Execution)
 
 // InProgress returns the matching in progress execution if exists
 func InProgress(ID string) (execution *Execution) {
@@ -16,24 +15,30 @@ func InProgress(ID string) (execution *Execution) {
 }
 
 func (execution *Execution) moveFromPendingToInProgress() error {
-	return execution.move("pending", pendingExecutions, inProgressExecutions)
-}
-
-func (execution *Execution) moveFromInProgressToProcessed() error {
-	return execution.move("inProgress", inProgressExecutions, processedExecutions)
-}
-
-func (execution *Execution) move(queue string, from, to map[string]*Execution) error {
 	mu.Lock()
 	defer mu.Unlock()
-	e, ok := from[execution.ID]
+	e, ok := pendingExecutions[execution.ID]
 	if !ok {
 		return &NotInQueueError{
 			ID:    execution.ID,
-			Queue: queue,
+			Queue: "pending",
 		}
 	}
-	to[execution.ID] = e
-	delete(from, execution.ID)
+	inProgressExecutions[execution.ID] = e
+	delete(pendingExecutions, execution.ID)
+	return nil
+}
+
+func (execution *Execution) deleteFromQueue() error {
+	mu.Lock()
+	defer mu.Unlock()
+	_, ok := inProgressExecutions[execution.ID]
+	if !ok {
+		return &NotInQueueError{
+			ID:    execution.ID,
+			Queue: "inProgress",
+		}
+	}
+	delete(inProgressExecutions, execution.ID)
 	return nil
 }

--- a/execution/state_test.go
+++ b/execution/state_test.go
@@ -29,9 +29,9 @@ func TestMoveFromPendingToInProgressNonExistingTask(t *testing.T) {
 	require.Nil(t, pendingExecutions[exec.ID])
 }
 
-func TestMoveFromInProgressToCompleted(t *testing.T) {
+func TestDeleteFromQueue(t *testing.T) {
 	s, _ := service.FromService(&service.Service{
-		Name: "TestMoveFromInProgressToCompleted",
+		Name: "TestDeleteFromQueue",
 		Tasks: []*service.Task{
 			{Key: "test"},
 		},
@@ -39,8 +39,7 @@ func TestMoveFromInProgressToCompleted(t *testing.T) {
 	var inputs map[string]interface{}
 	exec, _ := Create(s, "test", inputs, []string{})
 	exec.moveFromPendingToInProgress()
-	err := exec.moveFromInProgressToProcessed()
-	require.Equal(t, processedExecutions[exec.ID], exec)
+	err := exec.deleteFromQueue()
 	require.Nil(t, inProgressExecutions[exec.ID])
 	require.Nil(t, err)
 }
@@ -54,7 +53,7 @@ func TestMoveFromInProgressToCompletedNonExistingTask(t *testing.T) {
 	})
 	var inputs map[string]interface{}
 	exec, _ := Create(s, "test", inputs, []string{})
-	err := exec.moveFromInProgressToProcessed()
+	err := exec.deleteFromQueue()
 	require.NotNil(t, err)
 	require.Nil(t, inProgressExecutions[exec.ID])
 }


### PR DESCRIPTION
This might me really related to #540 
Every time we were executing a task, the executions was kept in memory, making the memory going up more and more over time.
This is a small fix to remove the execution when it's done. We should later on put that in a database but that will be another work