### PR TITLE
Change error msg to more explaining one

### DIFF
--- a/interface/grpc/service/submit_result.go
+++ b/interface/grpc/service/submit_result.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/mesg-foundation/core/protobuf/serviceapi"
 )
@@ -11,7 +12,7 @@ import (
 func (s *Server) SubmitResult(context context.Context, request *serviceapi.SubmitResultRequest) (*serviceapi.SubmitResultReply, error) {
 	var data map[string]interface{}
 	if err := json.Unmarshal([]byte(request.OutputData), &data); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("servcie sent invalid json data in %s output", request.OutputKey)
 	}
 	return &serviceapi.SubmitResultReply{}, s.api.SubmitResult(request.ExecutionID, request.OutputKey, data)
 }

--- a/interface/grpc/service/submit_result.go
+++ b/interface/grpc/service/submit_result.go
@@ -12,7 +12,7 @@ import (
 func (s *Server) SubmitResult(context context.Context, request *serviceapi.SubmitResultRequest) (*serviceapi.SubmitResultReply, error) {
 	var data map[string]interface{}
 	if err := json.Unmarshal([]byte(request.OutputData), &data); err != nil {
-		return nil, fmt.Errorf("servcie sent invalid json data in %s output", request.OutputKey)
+		return nil, fmt.Errorf("service sent invalid json data in output %q", request.OutputKey)
 	}
 	return &serviceapi.SubmitResultReply{}, s.api.SubmitResult(request.ExecutionID, request.OutputKey, data)
 }

--- a/interface/grpc/service/submit_result_test.go
+++ b/interface/grpc/service/submit_result_test.go
@@ -85,7 +85,7 @@ func TestSubmitWithInvalidJSON(t *testing.T) {
 		OutputKey:   outputKey,
 		OutputData:  "",
 	})
-	require.Equal(t, err.Error(), "unexpected end of JSON input")
+	require.Error(t, err)
 }
 
 func TestSubmitWithInvalidID(t *testing.T) {


### PR DESCRIPTION
close #562 

It turned out that https://github.com/mesg-foundation/service-webhook/blob/master/index.js#L16 here the output is a string (so invalid) and I've changed error message just. With the core everything is fine.