### PR TITLE
Improve xstructhash hash function

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -1,12 +1,10 @@
 package execution
 
 import (
-	"crypto/sha1"
-	"fmt"
 	"time"
 
-	"github.com/cnf/structhash"
 	"github.com/mesg-foundation/core/service"
+	"github.com/mesg-foundation/core/x/xstructhash"
 )
 
 // Status stores the state of an execution
@@ -56,7 +54,7 @@ func New(service *service.Service, eventID string, taskKey string, inputs map[st
 		CreatedAt: time.Now(),
 		Status:    Created,
 	}
-	exec.ID = fmt.Sprintf("%x", sha1.Sum(structhash.Dump(exec, 1)))
+	exec.ID = xstructhash.Hash(exec, 1)
 	return exec, nil
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -1,17 +1,16 @@
 package service
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"time"
 
-	"github.com/cnf/structhash"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/mesg-foundation/core/container"
 	"github.com/mesg-foundation/core/service/importer"
+	"github.com/mesg-foundation/core/x/xstructhash"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -159,9 +158,7 @@ func DeployStatusOption(statuses chan DeployStatus) Option {
 // have effect on computation but extending or removing configurations or changing
 // values in mesg.yml will cause computeHash to generate a different value.
 func (s *Service) computeHash() string {
-	h := sha1.New()
-	h.Write(structhash.Dump(s, 1))
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return xstructhash.Hash(s, 1)
 }
 
 // saveContext downloads service context to a temp dir.

--- a/x/xstructhash/structhash.go
+++ b/x/xstructhash/structhash.go
@@ -1,6 +1,8 @@
 package xstructhash
 
 import (
+	"fmt"
+
 	"github.com/cnf/structhash"
 )
 
@@ -10,7 +12,5 @@ import (
 // This function uses md5 hashing function and default formatter. See also Dump()
 // function.
 func Hash(c interface{}, version int) string {
-	// structhash.Hash always returns nil.
-	hash, _ := structhash.Hash(c, version)
-	return hash
+	return fmt.Sprintf("%x", structhash.Sha1(c, version))
 }

--- a/x/xstructhash/structhash_test.go
+++ b/x/xstructhash/structhash_test.go
@@ -1,14 +1,19 @@
 package xstructhash
 
 import (
+	"crypto/sha1"
+	"fmt"
 	"testing"
 
 	"github.com/cnf/structhash"
 )
 
 func TestHash(t *testing.T) {
-	hash := Hash(struct{}{}, 1)
-	if version := structhash.Version(hash); version != 1 {
-		t.Errorf("invalid version - got %d, want %d", version, 1)
+	s := struct{}{}
+	v := 1
+	got := Hash(s, v)
+	want := fmt.Sprintf("%x", sha1.Sum(structhash.Dump(s, v)))
+	if got != want {
+		t.Errorf("invalid hash")
 	}
 }


### PR DESCRIPTION
Update `xstructhash.Hash` function to use `structhash.Sha1(c, version)` that return the sha1 of the struct hash + version.
Also update 'custom' code that were doing exactly the same thing to use `xstructhash.Hash`.