### PR TITLE
Add rm flag to mesg-tool docker run command

### DIFF
--- a/mesg-tools
+++ b/mesg-tools
@@ -4,7 +4,7 @@
 docker build -t mesg/tools:local -f Dockerfile.tools .
 
 # shortland of container run command.
-run_in_container="docker run -ti -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:/core mesg/tools:local"
+run_in_container="docker run --rm -ti -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:/core mesg/tools:local"
 
 # run any command under dev container.
 $run_in_container $@


### PR DESCRIPTION
Add `--rm` flag to mesg-tool docker run command to remove the container once done.