### PR TITLE
Inject dependencies env from yaml to struct definition

### DIFF
--- a/service/inject_definition.go
+++ b/service/inject_definition.go
@@ -119,6 +119,7 @@ func (s *Service) defDependenciesToService(dependencies map[string]*importer.Dep
 			Ports:       dep.Ports,
 			Command:     dep.Command,
 			Args:        dep.Args,
+			Env:         dep.Env,
 		}
 	}
 	return deps


### PR DESCRIPTION
This PR allows env variable of dependencies declared in mesg.yml to be inject in the container.