### PR TITLE
Lint imports

### DIFF
--- a/interface/grpc/server.go
+++ b/interface/grpc/server.go
@@ -4,8 +4,6 @@ import (
 	"net"
 	"sync"
 
-	"github.com/mesg-foundation/core/systemservices"
-
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/mesg-foundation/core/api"
@@ -13,6 +11,7 @@ import (
 	"github.com/mesg-foundation/core/interface/grpc/service"
 	"github.com/mesg-foundation/core/protobuf/coreapi"
 	"github.com/mesg-foundation/core/protobuf/serviceapi"
+	"github.com/mesg-foundation/core/systemservices"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"

--- a/interface/grpc/server.go
+++ b/interface/grpc/server.go
@@ -4,8 +4,8 @@ import (
 	"net"
 	"sync"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/mesg-foundation/core/api"
 	"github.com/mesg-foundation/core/interface/grpc/core"
 	"github.com/mesg-foundation/core/interface/grpc/service"


### PR DESCRIPTION
Possible fix to https://circleci.com/gh/mesg-foundation/core/5359 

golangci-lint uses goimports with different set of options.

Also they have switched [imports tool](https://github.com/golangci/gofmt/commit/0b8337e80d98f7eec18e4504a4557b34423fd039) 6 days ago. So this probably the reason.

In circleci we use golang-lint v1.12 and 5 days ago they have relased [v1.12.5](https://github.com/golangci/golangci-lint/releases/tag/v1.12.5) which should be just for fixing bug (semver) but it broke our imports in fact.