### PR TITLE
Repeated parameters improvements

### DIFF
--- a/service/validation.go
+++ b/service/validation.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"reflect"
 )
 
 // ParameterWarning contains a specific warning related to a parameter.
@@ -51,12 +50,11 @@ func (v *parameterValidator) Validate(value interface{}) *ParameterWarning {
 	}
 	if v.parameter.Repeated {
 		// Check if the value is a slice
-		if reflect.TypeOf(value).Kind() != reflect.Slice {
+		array, ok := value.([]interface{})
+		if !ok {
 			return v.newParameterWarning("not an array")
 		}
-		array := reflect.ValueOf(value)
-		for i := 0; i < array.Len(); i++ {
-			x := array.Index(i).Interface() // Get the value as an interface{}
+		for _, x := range array {
 			if warning := v.validateType(x); warning != nil {
 				return warning
 			}

--- a/service/validation_test.go
+++ b/service/validation_test.go
@@ -82,7 +82,7 @@ func TestObject(t *testing.T) {
 func TestArray(t *testing.T) {
 	require.True(t, validateParameterData("array", []interface{}{"foo", "bar"}))
 	require.True(t, validateParameterData("array", []interface{}{}))
-	require.False(t, validateParameterData("array", []uint{10}))
+	require.False(t, validateParameterData("array", []interface{}{10}))
 	require.False(t, validateParameterData("array", 42))
 }
 

--- a/service/validation_test.go
+++ b/service/validation_test.go
@@ -80,8 +80,8 @@ func TestObject(t *testing.T) {
 }
 
 func TestArray(t *testing.T) {
-	require.True(t, validateParameterData("array", []string{"foo", "bar"}))
-	require.True(t, validateParameterData("array", []string{}))
+	require.True(t, validateParameterData("array", []interface{}{"foo", "bar"}))
+	require.True(t, validateParameterData("array", []interface{}{}))
 	require.False(t, validateParameterData("array", []uint{10}))
 	require.False(t, validateParameterData("array", 42))
 }
@@ -94,7 +94,7 @@ func TestValidateParameters(t *testing.T) {
 		"object": map[string]interface{}{
 			"foo": "bar",
 		},
-		"array": []string{"foo", "bar"},
+		"array": []interface{}{"foo", "bar"},
 	}), 0)
 	require.Len(t, validateParametersSchema(eventDataSchema, map[string]interface{}{
 		"optional": "yeah",
@@ -104,7 +104,7 @@ func TestValidateParameters(t *testing.T) {
 		"object": map[string]interface{}{
 			"foo": "bar",
 		},
-		"array": []string{"foo", "bar"},
+		"array": []interface{}{"foo", "bar"},
 	}), 0)
 	// 5 errors
 	//  - not required string


### PR DESCRIPTION
Improvement of https://github.com/mesg-foundation/core/pull/679

- Use type casting instead of reflection
- Update array test types from `[]string` to `[]interface{}`
- Update test to use data from JSON rather than go struct. That way, we don't choose any type, but let json.Unmarshal decide.