### PR TITLE
Fix/cli data flag

### DIFF
--- a/commands/service_deploy_test.go
+++ b/commands/service_deploy_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/commands/provider"
-	"github.com/mesg-foundation/core/x/xos"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +14,8 @@ func TestServiceDeployCmdFlags(t *testing.T) {
 	c := newServiceDeployCmd(nil)
 
 	flags := c.cmd.Flags()
-	flags.Set("env", "a=1,b=2")
+	flags.Set("env", "a=1")
+	flags.Set("env", "b=2")
 	require.Equal(t, map[string]string{"a": "1", "b": "2"}, c.env)
 }
 
@@ -23,12 +23,12 @@ func TestServiceDeploy(t *testing.T) {
 	var (
 		url                     = "1"
 		id                      = "2"
-		env                     = []string{"A=3", "B=4"}
+		env                     = map[string]string{"A": "3", "B": "4"}
 		m                       = newMockExecutor()
 		c                       = newServiceDeployCmd(m)
 		serviceDeployParameters = []interface{}{
 			url,
-			xos.EnvSliceToMap(env),
+			env,
 			mock.Anything,
 		}
 		serviceDeployRunFunction = func(args mock.Arguments) {
@@ -45,7 +45,7 @@ func TestServiceDeploy(t *testing.T) {
 		}
 	)
 	c.cmd.SetArgs([]string{url})
-	c.cmd.Flags().Set("env", strings.Join(env, ","))
+	c.env = env
 
 	m.On("ServiceDeploy", serviceDeployParameters...).Return(id, nil, nil).Run(serviceDeployRunFunction)
 

--- a/x/xpflag/string_to_string.go
+++ b/x/xpflag/string_to_string.go
@@ -8,36 +8,26 @@ import (
 
 // StringToStringValue flag.
 type StringToStringValue struct {
-	value     *map[string]string
-	separator string
-	changed   bool
+	value   *map[string]string
+	changed bool
 }
 
-// NewStringToStringValue creates new flag with init map, default value and comma separator.
+// NewStringToStringValue creates new flag with init map, default value.
 func NewStringToStringValue(p *map[string]string, value map[string]string) *StringToStringValue {
 	s := new(StringToStringValue)
-	s.separator = ","
 	s.value = p
 	*s.value = value
 	return s
 }
 
-// SetSeparator changes separator.
-func (s *StringToStringValue) SetSeparator(separator string) {
-	s.separator = separator
-}
-
 // Set value in format: a=1,b=2
 func (s *StringToStringValue) Set(val string) error {
-	ss := strings.Split(val, s.separator)
-	out := make(map[string]string, len(ss))
-	for _, pair := range ss {
-		kv := strings.SplitN(pair, "=", 2)
-		if len(kv) != 2 {
-			return fmt.Errorf("%s must be formatted as key=value", pair)
-		}
-		out[kv[0]] = kv[1]
+	out := make(map[string]string)
+	kv := strings.SplitN(val, "=", 2)
+	if len(kv) != 2 {
+		return fmt.Errorf("%s must be formatted as key=value", val)
 	}
+	out[kv[0]] = kv[1]
 	if !s.changed {
 		*s.value = out
 	} else {
@@ -59,7 +49,7 @@ func (s *StringToStringValue) String() string {
 	i := 0
 	for k, v := range *s.value {
 		if i > 0 {
-			buf.WriteString(s.separator)
+			buf.WriteString(" ")
 		}
 		buf.WriteString(k)
 		buf.WriteRune('=')

--- a/x/xpflag/string_to_string_test.go
+++ b/x/xpflag/string_to_string_test.go
@@ -1,7 +1,6 @@
 package xpflag
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 
@@ -18,19 +17,12 @@ func setUpS2SFlagSetWithDefault(s2sp *map[string]string) *pflag.FlagSet {
 	f.Var(NewStringToStringValue(s2sp, map[string]string{"a": "1", "b": "2"}), "s2s", "Command separated ls2st!")
 	return f
 }
-func createS2SFlag(vals map[string]string) string {
-	var buf bytes.Buffer
-	i := 0
+func createS2SFlag(vals map[string]string) []string {
+	var args []string
 	for k, v := range vals {
-		if i > 0 {
-			buf.WriteRune(',')
-		}
-		buf.WriteString(k)
-		buf.WriteRune('=')
-		buf.WriteString(v)
-		i++
+		args = append(args, "--s2s="+k+"="+v)
 	}
-	return buf.String()
+	return args
 }
 func TestEmptyS2S(t *testing.T) {
 	var s2s map[string]string
@@ -55,11 +47,12 @@ func TestS2S(t *testing.T) {
 	var s2s map[string]string
 	f := setUpS2SFlagSet(&s2s)
 	vals := map[string]string{"a": "1", "b": "2", "d": "4", "c": "3"}
-	arg := fmt.Sprintf("--s2s=%s", createS2SFlag(vals))
-	err := f.Parse([]string{arg})
+	args := createS2SFlag(vals)
+	err := f.Parse(args)
 	if err != nil {
 		t.Fatal("expected no error; got", err)
 	}
+
 	for k, v := range s2s {
 		if vals[k] != v {
 			t.Fatalf("expected s2s[%s] to be %s but got: %s", k, vals[k], v)
@@ -110,8 +103,8 @@ func TestS2SWithDefault(t *testing.T) {
 	var s2s map[string]string
 	f := setUpS2SFlagSetWithDefault(&s2s)
 	vals := map[string]string{"a": "1", "b": "2"}
-	arg := fmt.Sprintf("--s2s=%s", createS2SFlag(vals))
-	err := f.Parse([]string{arg})
+	args := createS2SFlag(vals)
+	err := f.Parse(args)
 	if err != nil {
 		t.Fatal("expected no error; got", err)
 	}
@@ -137,7 +130,7 @@ func TestS2SWithDefault(t *testing.T) {
 func TestS2SCalledTwice(t *testing.T) {
 	var s2s map[string]string
 	f := setUpS2SFlagSet(&s2s)
-	in := []string{"a=1,b=2", "b=3"}
+	in := []string{"a=1", "b=3"}
 	expected := map[string]string{"a": "1", "b": "3"}
 	argfmt := "--s2s=%s"
 	arg1 := fmt.Sprintf(argfmt, in[0])


### PR DESCRIPTION
fix #681 

Pass array with data flag: `--data array=a,b,c`

Flag `--data-separator` or similar will be done in a diffrent PR