### PR TITLE
Use GOCACHE in .circleci to keep go get repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,24 @@ runOnDocker: &runOnDocker
 jobs:
   "test":
     <<: *runOnDocker
+    environment:
+      - GOCACHE: "/tmp/go/cache"
     steps:
       - checkout
       - setup_remote_docker
       - run: docker swarm init
       - run: docker build -t sleep docker-images/sleep/
       - run: docker build -t http-server docker-images/http-server/
+      - restore_cache:
+          keys:
+            - test-cache-{{ .Branch }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+            - test-cache-{{ .Branch }}
       - run: mkdir -p ~/.mesg && ln -s /go/src/github.com/mesg-foundation/core/systemservices/sources ~/.mesg/systemservices
       - run: go test -v -timeout 300s -p 1 -tags=integration -coverprofile=coverage.txt ./...
+      - save_cache:
+          key: test-cache-{{ .Branch }}-{{ .BuildNum }}
+          paths:
+            - /tmp/go/cache
       - run: bash <(curl -s https://codecov.io/bash)
 
   "lint":


### PR DESCRIPTION
This one is exactly the same as https://github.com/mesg-foundation/core/pull/561, but coverprofile is untouched. In this case, when we remove vendor files we will still have cache for go get files.