### PR TITLE
Return error before waiting in command dev and deploy

### DIFF
--- a/commands/service_deploy.go
+++ b/commands/service_deploy.go
@@ -56,12 +56,12 @@ func (c *serviceDeployCmd) runE(cmd *cobra.Command, args []string) error {
 	}()
 
 	id, validationError, err := c.e.ServiceDeploy(c.path, c.env, statuses)
-	wg.Wait()
-
-	pretty.DestroySpinner()
 	if err != nil {
 		return err
 	}
+	wg.Wait()
+
+	pretty.DestroySpinner()
 	if validationError != nil {
 		return xerrors.Errors{
 			validationError,

--- a/commands/service_dev.go
+++ b/commands/service_dev.go
@@ -66,12 +66,12 @@ func (c *serviceDevCmd) runE(cmd *cobra.Command, args []string) error {
 	}()
 
 	id, validationError, err := c.e.ServiceDeploy(c.path, c.env, statuses)
-	wg.Wait()
-
-	pretty.DestroySpinner()
 	if err != nil {
 		return err
 	}
+	wg.Wait()
+
+	pretty.DestroySpinner()
 	if validationError != nil {
 		return xerrors.Errors{
 			validationError,


### PR DESCRIPTION
Fix behavior when the core is stopped the command dev and deploy were "waiting" forever without returning error