### PR TITLE
Multiple argument for service start/stop commands

### DIFF
--- a/commands/service_start.go
+++ b/commands/service_start.go
@@ -20,24 +20,24 @@ func newServiceStartCmd(e ServiceExecutor) *serviceStartCmd {
 		Short:   "Start a service",
 		Long:    "Start a service previously published services",
 		Example: `mesg-core service start SERVICE`,
-		Args:    cobra.ExactArgs(1),
 		RunE:    c.runE,
 	})
 	return c
 }
 
 func (c *serviceStartCmd) runE(cmd *cobra.Command, args []string) error {
-	var (
-		serviceID = args[0]
-		err       error
-	)
-	pretty.Progress("Starting service...", func() {
-		err = c.e.ServiceStart(serviceID)
-	})
-	if err != nil {
-		return err
+	for _, serviceID := range args {
+		var err error
+		pretty.Progress("Starting service...", func() {
+			err = c.e.ServiceStart(serviceID)
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s Service %q started\n", pretty.SuccessSign, serviceID)
+		if len(args) == 1 {
+			fmt.Printf("To see its logs, run the command:\n\tmesg-core service logs %s\n", serviceID)
+		}
 	}
-	fmt.Printf("%s Service started\n", pretty.SuccessSign)
-	fmt.Printf("To see its logs, run the command:\n\tmesg-core service logs %s\n", serviceID)
 	return nil
 }

--- a/commands/service_start.go
+++ b/commands/service_start.go
@@ -34,7 +34,7 @@ func (c *serviceStartCmd) runE(cmd *cobra.Command, args []string) error {
 				err = c.e.ServiceStart(serviceID)
 			}
 		}(arg)
-		pretty.Progress("Starting service...", fn)
+		pretty.Progress(fmt.Sprintf("Starting service %q...", arg), fn)
 		if err != nil {
 			return err
 		}

--- a/commands/service_start.go
+++ b/commands/service_start.go
@@ -26,17 +26,21 @@ func newServiceStartCmd(e ServiceExecutor) *serviceStartCmd {
 }
 
 func (c *serviceStartCmd) runE(cmd *cobra.Command, args []string) error {
-	for _, serviceID := range args {
+	for _, arg := range args {
 		var err error
-		pretty.Progress("Starting service...", func() {
-			err = c.e.ServiceStart(serviceID)
-		})
+		// build function to avoid using arg inside progress
+		fn := func(serviceID string) func() {
+			return func() {
+				err = c.e.ServiceStart(serviceID)
+			}
+		}(arg)
+		pretty.Progress("Starting service...", fn)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s Service %q started\n", pretty.SuccessSign, serviceID)
+		fmt.Printf("%s Service %q started\n", pretty.SuccessSign, arg)
 		if len(args) == 1 {
-			fmt.Printf("To see its logs, run the command:\n\tmesg-core service logs %s\n", serviceID)
+			fmt.Printf("To see its logs, run the command:\n\tmesg-core service logs %s\n", arg)
 		}
 	}
 	return nil

--- a/commands/service_start.go
+++ b/commands/service_start.go
@@ -19,7 +19,7 @@ func newServiceStartCmd(e ServiceExecutor) *serviceStartCmd {
 		Use:     "start SERVICE",
 		Short:   "Start a service",
 		Long:    "Start a service previously published services",
-		Example: `mesg-core service start SERVICE`,
+		Example: `mesg-core service start SERVICE [SERVICE...]`,
 		RunE:    c.runE,
 	})
 	return c

--- a/commands/service_stop.go
+++ b/commands/service_stop.go
@@ -19,20 +19,21 @@ func newServiceStopCmd(e ServiceExecutor) *serviceStopCmd {
 		Use:     "stop SERVICE",
 		Short:   "Stop a service",
 		Example: `mesg-core service stop SERVICE`,
-		Args:    cobra.ExactArgs(1),
 		RunE:    c.runE,
 	})
 	return c
 }
 
 func (c *serviceStopCmd) runE(cmd *cobra.Command, args []string) error {
-	var err error
-	pretty.Progress("Stopping service...", func() {
-		err = c.e.ServiceStop(args[0])
-	})
-	if err != nil {
-		return err
+	for _, serviceID := range args {
+		var err error
+		pretty.Progress("Stopping service...", func() {
+			err = c.e.ServiceStop(serviceID)
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s Service %q stopped\n", pretty.SuccessSign, serviceID)
 	}
-	fmt.Printf("%s Service stopped\n", pretty.SuccessSign)
 	return nil
 }

--- a/commands/service_stop.go
+++ b/commands/service_stop.go
@@ -18,7 +18,7 @@ func newServiceStopCmd(e ServiceExecutor) *serviceStopCmd {
 	c.cmd = newCommand(&cobra.Command{
 		Use:     "stop SERVICE",
 		Short:   "Stop a service",
-		Example: `mesg-core service stop SERVICE`,
+		Example: `mesg-core service stop SERVICE [SERVICE...]`,
 		RunE:    c.runE,
 	})
 	return c

--- a/commands/service_stop.go
+++ b/commands/service_stop.go
@@ -25,15 +25,19 @@ func newServiceStopCmd(e ServiceExecutor) *serviceStopCmd {
 }
 
 func (c *serviceStopCmd) runE(cmd *cobra.Command, args []string) error {
-	for _, serviceID := range args {
+	for _, arg := range args {
 		var err error
-		pretty.Progress("Stopping service...", func() {
-			err = c.e.ServiceStop(serviceID)
-		})
+		// build function to avoid using arg inside progress
+		fn := func(serviceID string) func() {
+			return func() {
+				err = c.e.ServiceStop(serviceID)
+			}
+		}(arg)
+		pretty.Progress("Stopping service...", fn)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s Service %q stopped\n", pretty.SuccessSign, serviceID)
+		fmt.Printf("%s Service %q stopped\n", pretty.SuccessSign, arg)
 	}
 	return nil
 }

--- a/commands/service_stop.go
+++ b/commands/service_stop.go
@@ -33,7 +33,7 @@ func (c *serviceStopCmd) runE(cmd *cobra.Command, args []string) error {
 				err = c.e.ServiceStop(serviceID)
 			}
 		}(arg)
-		pretty.Progress("Stopping service...", fn)
+		pretty.Progress(fmt.Sprintf("Stopping service %q...", arg), fn)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
It is now possible to call the commands `service start` and `service stop` with multiple arguments and not only one.

```bash
mesg-core service stop sid1 sid2 sid3...
```
