### PR TITLE
Create stream autoreconnect simple version

### DIFF
--- a/client/service/service.go
+++ b/client/service/service.go
@@ -142,7 +142,7 @@ func (s *Service) setupServiceClient() error {
 	if err != nil {
 		return err
 	}
-	s.client = serviceapi.NewServiceClientSafe(s.conn, serviceapi.OnError)
+	s.client = serviceapi.NewServiceClientSafe(s.conn)
 	return nil
 }
 

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -178,6 +178,9 @@ func (s *Service) listenTasks() error {
 	if err != nil {
 		return err
 	}
+	if err := acknowledgement.WaitForStreamToBeReady(stream); err != nil {
+		return err
+	}
 	for {
 		s.gracefulWait.Add(1)
 		data, err := stream.Recv()

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -16,6 +16,7 @@ import (
 
 	"context"
 
+	"github.com/mesg-foundation/core/protobuf/acknowledgement"
 	"github.com/mesg-foundation/core/protobuf/serviceapi"
 	"google.golang.org/grpc"
 )

--- a/client/service/servicetest/service.go
+++ b/client/service/servicetest/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mesg-foundation/core/protobuf/acknowledgement"
 	"github.com/mesg-foundation/core/protobuf/serviceapi"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // serviceServer implements MESG's service server.
@@ -92,6 +93,10 @@ func (s taskDataStream) Send(data *serviceapi.TaskData) error {
 
 func (s taskDataStream) Context() context.Context {
 	return s.ctx
+}
+
+func (s taskDataStream) SendHeader(md metadata.MD) error {
+	return nil
 }
 
 func (s taskDataStream) close() {

--- a/client/service/servicetest/service.go
+++ b/client/service/servicetest/service.go
@@ -3,6 +3,7 @@ package servicetest
 import (
 	"context"
 
+	"github.com/mesg-foundation/core/protobuf/acknowledgement"
 	"github.com/mesg-foundation/core/protobuf/serviceapi"
 	"google.golang.org/grpc"
 )
@@ -39,6 +40,10 @@ func (s *serviceServer) EmitEvent(context context.Context,
 func (s *serviceServer) ListenTask(request *serviceapi.ListenTaskRequest,
 	stream serviceapi.Service_ListenTaskServer) (err error) {
 	s.token = request.Token
+
+	if err := acknowledgement.SetStreamReady(stream); err != nil {
+		return err
+	}
 
 	for {
 		select {

--- a/commands/provider/service_provider.go
+++ b/commands/provider/service_provider.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	"github.com/mesg-foundation/core/commands/provider/assets"
+	"github.com/mesg-foundation/core/protobuf/acknowledgement"
 	"github.com/mesg-foundation/core/protobuf/coreapi"
 	"github.com/mesg-foundation/core/service/importer"
 	"github.com/mesg-foundation/core/utils/chunker"
@@ -104,6 +105,10 @@ func (p *ServiceProvider) ServiceListenEvents(id, eventFilter string) (chan *cor
 		}
 	}()
 
+	if err := acknowledgement.WaitForStreamToBeReady(stream); err != nil {
+		return nil, nil, err
+	}
+
 	return resultC, errC, nil
 }
 
@@ -131,6 +136,10 @@ func (p *ServiceProvider) ServiceListenResults(id, taskFilter, outputFilter stri
 			}
 		}
 	}()
+
+	if err := acknowledgement.WaitForStreamToBeReady(stream); err != nil {
+		return nil, nil, err
+	}
 
 	return resultC, errC, nil
 }
@@ -189,6 +198,10 @@ func (p *ServiceProvider) ServiceLogs(id string, dependencies ...string) (logs [
 		<-errC
 		closer()
 	}()
+
+	if err := acknowledgement.WaitForStreamToBeReady(stream); err != nil {
+		return nil, nil, err
+	}
 
 	return logs, closer, nil
 }

--- a/interface/cli/main.go
+++ b/interface/cli/main.go
@@ -35,7 +35,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	p := provider.New(coreapi.NewCoreClientSafe(connection, coreapi.OnError), daemon.NewContainerDaemon(cfg, c))
+	p := provider.New(coreapi.NewCoreClientSafe(connection), daemon.NewContainerDaemon(cfg, c))
 	cmd := commands.Build(p)
 	cmd.Version = version.Version
 	cmd.Short = cmd.Short + " " + version.Version

--- a/protobuf/coreapi/client_safe.go
+++ b/protobuf/coreapi/client_safe.go
@@ -15,36 +15,36 @@ type CoreClientSafe struct {
 	CoreClient
 }
 
-// NewCoreClient creates core client with reconnection.
+// NewCoreClientSafe creates core client with reconnection.
 func NewCoreClientSafe(cc *grpc.ClientConn) *CoreClientSafe {
 	return &CoreClientSafe{
 		CoreClient: NewCoreClient(cc),
 	}
 }
 
-// core_ListenEventClient is a client with reconnection.
-type core_ListenEventClient struct {
+// coreListenEventClientSafe is a client with reconnection.
+type coreListenEventClientSafe struct {
 	Core_ListenEventClient
 
 	client *CoreClientSafe
-	c      chan *core_ListenEventClientResponse
+	c      chan *coreListenEventClientSafeResponse
 
 	ctx  context.Context
 	in   *ListenEventRequest
 	opts []grpc.CallOption
 }
 
-// core_ListenEventClientResponse wraps ListenEvent recv response.
-type core_ListenEventClientResponse struct {
+// coreListenEventClientSafeResponse wraps ListenEvent recv response.
+type coreListenEventClientSafeResponse struct {
 	eventData *EventData
 	err       error
 }
 
-// newCore_ListenEventClient creates core ListenEvent client.
-func newCore_ListenEventClient(client *CoreClientSafe, ctx context.Context, in *ListenEventRequest, opts ...grpc.CallOption) *core_ListenEventClient {
-	c := &core_ListenEventClient{
+// newCoreListenEventClientSafe creates core ListenEvent client.
+func newCoreListenEventClientSafe(client *CoreClientSafe, ctx context.Context, in *ListenEventRequest, opts ...grpc.CallOption) *coreListenEventClientSafe {
+	c := &coreListenEventClientSafe{
 		client: client,
-		c:      make(chan *core_ListenEventClientResponse),
+		c:      make(chan *coreListenEventClientSafeResponse),
 
 		ctx:  ctx,
 		in:   in,
@@ -57,7 +57,7 @@ func newCore_ListenEventClient(client *CoreClientSafe, ctx context.Context, in *
 }
 
 // recvLoop receives ListenEvent response in loop and reconnect in on error.
-func (s *core_ListenEventClient) recvLoop(waitStream chan struct{}) {
+func (s *coreListenEventClientSafe) recvLoop(waitStream chan struct{}) {
 	var err error
 loop:
 	for {
@@ -65,7 +65,7 @@ loop:
 		s.Core_ListenEventClient, err = s.client.CoreClient.ListenEvent(s.ctx, s.in, s.opts...)
 		waitStream <- struct{}{}
 		if err != nil {
-			s.c <- &core_ListenEventClientResponse{nil, err}
+			s.c <- &coreListenEventClientSafeResponse{nil, err}
 			continue
 		}
 
@@ -83,7 +83,7 @@ loop:
 
 		for {
 			td, err := s.Core_ListenEventClient.Recv()
-			s.c <- &core_ListenEventClientResponse{td, err}
+			s.c <- &coreListenEventClientSafeResponse{td, err}
 			if err != nil {
 				done <- struct{}{}
 				// in case of EOF end loop
@@ -100,39 +100,39 @@ loop:
 }
 
 // Recv receives data from streams.
-func (s *core_ListenEventClient) Recv() (*EventData, error) {
+func (s *coreListenEventClientSafe) Recv() (*EventData, error) {
 	v := <-s.c
 	return v.eventData, v.err
 }
 
-// ListenEvent subscribe to a stream that listens for events from a service.
+// ListenEvent subscribes to a stream that listens for events from a service.
 func (c *CoreClientSafe) ListenEvent(ctx context.Context, in *ListenEventRequest, opts ...grpc.CallOption) (Core_ListenEventClient, error) {
-	return newCore_ListenEventClient(c, ctx, in, opts...), nil
+	return newCoreListenEventClientSafe(c, ctx, in, opts...), nil
 }
 
-// core_ListenResultClient is a client with reconnection.
-type core_ListenResultClient struct {
+// coreListenResultClientSafe is a client with reconnection.
+type coreListenResultClientSafe struct {
 	Core_ListenResultClient
 
 	client *CoreClientSafe
-	c      chan *core_ListenResultClientResponse
+	c      chan *coreListenResultClientSafeResponse
 
 	ctx  context.Context
 	in   *ListenResultRequest
 	opts []grpc.CallOption
 }
 
-// core_ListenResultClientResponse wraps ListenResult recv response.
-type core_ListenResultClientResponse struct {
+// coreListenResultClientSafeResponse wraps ListenResult recv response.
+type coreListenResultClientSafeResponse struct {
 	resultData *ResultData
 	err        error
 }
 
-// newCore_ListenResultClient creates core ListenResult client.
-func newCore_ListenResultClient(client *CoreClientSafe, ctx context.Context, in *ListenResultRequest, opts ...grpc.CallOption) *core_ListenResultClient {
-	c := &core_ListenResultClient{
+// newCoreListenResultClientSafe creates core ListenResult client.
+func newCoreListenResultClientSafe(client *CoreClientSafe, ctx context.Context, in *ListenResultRequest, opts ...grpc.CallOption) *coreListenResultClientSafe {
+	c := &coreListenResultClientSafe{
 		client: client,
-		c:      make(chan *core_ListenResultClientResponse),
+		c:      make(chan *coreListenResultClientSafeResponse),
 
 		ctx:  ctx,
 		in:   in,
@@ -145,7 +145,7 @@ func newCore_ListenResultClient(client *CoreClientSafe, ctx context.Context, in 
 }
 
 // recvLoop receives ListenResult response in loop and reconnect in on error.
-func (s *core_ListenResultClient) recvLoop(waitStream chan struct{}) {
+func (s *coreListenResultClientSafe) recvLoop(waitStream chan struct{}) {
 	var err error
 loop:
 	for {
@@ -153,7 +153,7 @@ loop:
 		s.Core_ListenResultClient, err = s.client.CoreClient.ListenResult(s.ctx, s.in, s.opts...)
 		waitStream <- struct{}{}
 		if err != nil {
-			s.c <- &core_ListenResultClientResponse{nil, err}
+			s.c <- &coreListenResultClientSafeResponse{nil, err}
 			continue
 		}
 
@@ -171,7 +171,7 @@ loop:
 
 		for {
 			td, err := s.Core_ListenResultClient.Recv()
-			s.c <- &core_ListenResultClientResponse{td, err}
+			s.c <- &coreListenResultClientSafeResponse{td, err}
 			if err != nil {
 				done <- struct{}{}
 				// in case of EOF end loop
@@ -188,38 +188,39 @@ loop:
 }
 
 // Recv receives data from streams.
-func (s *core_ListenResultClient) Recv() (*ResultData, error) {
+func (s *coreListenResultClientSafe) Recv() (*ResultData, error) {
 	v := <-s.c
 	return v.resultData, v.err
 }
 
+// ListenResult subscribes to a stream that listens for results from a service.
 func (c *CoreClientSafe) ListenResult(ctx context.Context, in *ListenResultRequest, opts ...grpc.CallOption) (Core_ListenResultClient, error) {
-	return newCore_ListenResultClient(c, ctx, in, opts...), nil
+	return newCoreListenResultClientSafe(c, ctx, in, opts...), nil
 }
 
-// core_ServiceLogsClient is a client with reconnection.
-type core_ServiceLogsClient struct {
+// coreServiceLogsClientSafe is a client with reconnection.
+type coreServiceLogsClientSafe struct {
 	Core_ServiceLogsClient
 
 	client *CoreClientSafe
-	c      chan *core_ServiceLogsClientResponse
+	c      chan *coreServiceLogsClientSafeResponse
 
 	ctx  context.Context
 	in   *ServiceLogsRequest
 	opts []grpc.CallOption
 }
 
-// core_ServiceLogsClientResponse wraps ServiceLogs recv response.
-type core_ServiceLogsClientResponse struct {
+// coreServiceLogsClientSafeResponse wraps ServiceLogs recv response.
+type coreServiceLogsClientSafeResponse struct {
 	logData *LogData
 	err     error
 }
 
-// newCore_ServiceLogsClient creates core ServiceLogs client.
-func newCore_ServiceLogsClient(client *CoreClientSafe, ctx context.Context, in *ServiceLogsRequest, opts ...grpc.CallOption) *core_ServiceLogsClient {
-	c := &core_ServiceLogsClient{
+// newCoreServiceLogsClientSafe creates core ServiceLogs client.
+func newCoreServiceLogsClientSafe(client *CoreClientSafe, ctx context.Context, in *ServiceLogsRequest, opts ...grpc.CallOption) *coreServiceLogsClientSafe {
+	c := &coreServiceLogsClientSafe{
 		client: client,
-		c:      make(chan *core_ServiceLogsClientResponse),
+		c:      make(chan *coreServiceLogsClientSafeResponse),
 
 		ctx:  ctx,
 		in:   in,
@@ -232,7 +233,7 @@ func newCore_ServiceLogsClient(client *CoreClientSafe, ctx context.Context, in *
 }
 
 // recvLoop receives ServiceLogs response in loop and reconnect in on error.
-func (s *core_ServiceLogsClient) recvLoop(waitStream chan struct{}) {
+func (s *coreServiceLogsClientSafe) recvLoop(waitStream chan struct{}) {
 	var err error
 loop:
 	for {
@@ -240,7 +241,7 @@ loop:
 		s.Core_ServiceLogsClient, err = s.client.CoreClient.ServiceLogs(s.ctx, s.in, s.opts...)
 		waitStream <- struct{}{}
 		if err != nil {
-			s.c <- &core_ServiceLogsClientResponse{nil, err}
+			s.c <- &coreServiceLogsClientSafeResponse{nil, err}
 			continue
 		}
 
@@ -258,7 +259,7 @@ loop:
 
 		for {
 			td, err := s.Core_ServiceLogsClient.Recv()
-			s.c <- &core_ServiceLogsClientResponse{td, err}
+			s.c <- &coreServiceLogsClientSafeResponse{td, err}
 			if err != nil {
 				done <- struct{}{}
 				// in case of EOF end loop
@@ -275,11 +276,12 @@ loop:
 }
 
 // Recv receives data from streams.
-func (s *core_ServiceLogsClient) Recv() (*LogData, error) {
+func (s *coreServiceLogsClientSafe) Recv() (*LogData, error) {
 	v := <-s.c
 	return v.logData, v.err
 }
 
+// ServiceLogs subscribes to a stream that listens for logs from a service.
 func (c *CoreClientSafe) ServiceLogs(ctx context.Context, in *ServiceLogsRequest, opts ...grpc.CallOption) (Core_ServiceLogsClient, error) {
-	return newCore_ServiceLogsClient(c, ctx, in, opts...), nil
+	return newCoreServiceLogsClientSafe(c, ctx, in, opts...), nil
 }

--- a/protobuf/coreapi/client_safe.go
+++ b/protobuf/coreapi/client_safe.go
@@ -50,17 +50,20 @@ func newCore_ListenEventClient(client *CoreClientSafe, ctx context.Context, in *
 		in:   in,
 		opts: opts,
 	}
-	go c.recvLoop()
+	waitStream := make(chan struct{}, 1)
+	go c.recvLoop(waitStream)
+	<-waitStream
 	return c
 }
 
 // recvLoop receives ListenEvent response in loop and reconnect in on error.
-func (s *core_ListenEventClient) recvLoop() {
+func (s *core_ListenEventClient) recvLoop(waitStream chan struct{}) {
 	var err error
 loop:
 	for {
 		// connect
 		s.Core_ListenEventClient, err = s.client.CoreClient.ListenEvent(s.ctx, s.in, s.opts...)
+		waitStream <- struct{}{}
 		if err != nil {
 			s.c <- &core_ListenEventClientResponse{nil, err}
 			continue
@@ -135,17 +138,20 @@ func newCore_ListenResultClient(client *CoreClientSafe, ctx context.Context, in 
 		in:   in,
 		opts: opts,
 	}
-	go c.recvLoop()
+	waitStream := make(chan struct{}, 1)
+	go c.recvLoop(waitStream)
+	<-waitStream
 	return c
 }
 
 // recvLoop receives ListenResult response in loop and reconnect in on error.
-func (s *core_ListenResultClient) recvLoop() {
+func (s *core_ListenResultClient) recvLoop(waitStream chan struct{}) {
 	var err error
 loop:
 	for {
 		// connect
 		s.Core_ListenResultClient, err = s.client.CoreClient.ListenResult(s.ctx, s.in, s.opts...)
+		waitStream <- struct{}{}
 		if err != nil {
 			s.c <- &core_ListenResultClientResponse{nil, err}
 			continue
@@ -219,17 +225,20 @@ func newCore_ServiceLogsClient(client *CoreClientSafe, ctx context.Context, in *
 		in:   in,
 		opts: opts,
 	}
-	go c.recvLoop()
+	waitStream := make(chan struct{}, 1)
+	go c.recvLoop(waitStream)
+	<-waitStream
 	return c
 }
 
 // recvLoop receives ServiceLogs response in loop and reconnect in on error.
-func (s *core_ServiceLogsClient) recvLoop() {
+func (s *core_ServiceLogsClient) recvLoop(waitStream chan struct{}) {
 	var err error
 loop:
 	for {
 		// connect
 		s.Core_ServiceLogsClient, err = s.client.CoreClient.ServiceLogs(s.ctx, s.in, s.opts...)
+		waitStream <- struct{}{}
 		if err != nil {
 			s.c <- &core_ServiceLogsClientResponse{nil, err}
 			continue

--- a/protobuf/coreapi/client_safe.go
+++ b/protobuf/coreapi/client_safe.go
@@ -9,27 +9,16 @@ import (
 	"google.golang.org/grpc"
 )
 
-// ReconnectStrategy for grpc stream.
-type ReconnectStrategy int
-
-// Possible Reconnect Strategy for grpc stream.
-const (
-	Never ReconnectStrategy = iota
-	OnError
-)
-
 const reconnectDelay = 3 * time.Second
 
 // CoreClientSafe provides CoreClient with stream reconnection.
 type CoreClientSafe struct {
-	reconnect ReconnectStrategy
 	CoreClient
 }
 
 // NewCoreClient creates core client with reconnection.
-func NewCoreClientSafe(cc *grpc.ClientConn, rc ReconnectStrategy) *CoreClientSafe {
+func NewCoreClientSafe(cc *grpc.ClientConn) *CoreClientSafe {
 	return &CoreClientSafe{
-		reconnect:  rc,
 		CoreClient: NewCoreClient(cc),
 	}
 }
@@ -156,9 +145,6 @@ func (s *core_ListenEventClient) Recv() (*EventData, error) {
 
 // ListenEvent subscribe to a stream that listens for events from a service.
 func (c *CoreClientSafe) ListenEvent(ctx context.Context, in *ListenEventRequest, opts ...grpc.CallOption) (Core_ListenEventClient, error) {
-	if c.reconnect == Never {
-		return c.listenEvent(ctx, in, opts...)
-	}
 	return newCore_ListenEventClient(c, ctx, in, opts...), nil
 }
 
@@ -243,9 +229,6 @@ func (s *core_ListenResultClient) Recv() (*ResultData, error) {
 }
 
 func (c *CoreClientSafe) ListenResult(ctx context.Context, in *ListenResultRequest, opts ...grpc.CallOption) (Core_ListenResultClient, error) {
-	if c.reconnect == Never {
-		return c.listenResult(ctx, in, opts...)
-	}
 	return newCore_ListenResultClient(c, ctx, in, opts...), nil
 }
 
@@ -334,8 +317,5 @@ func (s *core_ServiceLogsClient) Recv() (*LogData, error) {
 }
 
 func (c *CoreClientSafe) ServiceLogs(ctx context.Context, in *ServiceLogsRequest, opts ...grpc.CallOption) (Core_ServiceLogsClient, error) {
-	if c.reconnect == Never {
-		return c.serviceLogs(ctx, in, opts...)
-	}
 	return newCore_ServiceLogsClient(c, ctx, in, opts...), nil
 }

--- a/protobuf/coreapi/client_safe_test.go
+++ b/protobuf/coreapi/client_safe_test.go
@@ -35,7 +35,7 @@ func newCoreClientSafe(t *testing.T) *CoreClientSafe {
 		t.Fatal(err)
 	}
 
-	return NewCoreClientSafe(conn, OnError)
+	return NewCoreClientSafe(conn)
 }
 
 func TestListenEventReconnect(t *testing.T) {

--- a/protobuf/serviceapi/client_safe.go
+++ b/protobuf/serviceapi/client_safe.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/mesg-foundation/core/protobuf/acknowledgement"
 	"google.golang.org/grpc"
 )
 
@@ -21,18 +20,6 @@ func NewServiceClientSafe(cc *grpc.ClientConn) *ServiceClientSafe {
 	return &ServiceClientSafe{
 		ServiceClient: NewServiceClient(cc),
 	}
-}
-
-// listenTask returns listen task client.
-func (s *ServiceClientSafe) listenTask(ctx context.Context, in *ListenTaskRequest, opts ...grpc.CallOption) (Service_ListenTaskClient, error) {
-	client, err := s.ServiceClient.ListenTask(ctx, in, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if err := acknowledgement.WaitForStreamToBeReady(client); err != nil {
-		return nil, err
-	}
-	return client, err
 }
 
 // core_ListenTaskClient is a client with reconnection.
@@ -73,7 +60,7 @@ func (s *core_ListenTaskClient) recvLoop() {
 loop:
 	for {
 		// connect
-		s.Service_ListenTaskClient, err = s.client.listenTask(s.ctx, s.in, s.opts...)
+		s.Service_ListenTaskClient, err = s.client.ServiceClient.ListenTask(s.ctx, s.in, s.opts...)
 		if err != nil {
 			s.c <- &core_ListenTaskClientResponse{nil, err}
 			continue

--- a/protobuf/serviceapi/client_safe.go
+++ b/protobuf/serviceapi/client_safe.go
@@ -9,27 +9,16 @@ import (
 	"google.golang.org/grpc"
 )
 
-// ReconnectStrategy for grpc stream.
-type ReconnectStrategy int
-
-// Possible Reconnect Strategy for grpc stream.
-const (
-	Never ReconnectStrategy = iota
-	OnError
-)
-
 const reconnectDelay = 3 * time.Second
 
 // ServiceClientSafe provides ServiceClient with stream reconnection.
 type ServiceClientSafe struct {
-	reconnect ReconnectStrategy
 	ServiceClient
 }
 
 // NewServiceClient creates core client with reconnection.
-func NewServiceClientSafe(cc *grpc.ClientConn, rc ReconnectStrategy) *ServiceClientSafe {
+func NewServiceClientSafe(cc *grpc.ClientConn) *ServiceClientSafe {
 	return &ServiceClientSafe{
-		reconnect:     rc,
 		ServiceClient: NewServiceClient(cc),
 	}
 }
@@ -127,8 +116,5 @@ func (s *core_ListenTaskClient) Recv() (*TaskData, error) {
 }
 
 func (c *ServiceClientSafe) ListenTask(ctx context.Context, in *ListenTaskRequest, opts ...grpc.CallOption) (Service_ListenTaskClient, error) {
-	if c.reconnect == Never {
-		return c.listenTask(ctx, in, opts...)
-	}
 	return newService_ListenTaskClient(c, ctx, in, opts...), nil
 }

--- a/protobuf/serviceapi/client_safe_test.go
+++ b/protobuf/serviceapi/client_safe_test.go
@@ -35,7 +35,7 @@ func newServiceClinetSafe(t *testing.T) *ServiceClientSafe {
 		t.Fatal(err)
 	}
 
-	return NewServiceClientSafe(conn, OnError)
+	return NewServiceClientSafe(conn)
 }
 
 func TestListenTaskReconnect(t *testing.T) {


### PR DESCRIPTION
Simplification of #717

- No acknowledgement system in the safe clients
- No choice of reconnect strategy. Always reconnect

- Add acknowledgement system in `client/service`

- FIX BUG where function that create stream didn't wait for it to be actually created resulting in pointer error with the acknowledgement system

- Improve naming. Follow gRPC way to name stuff