### PR TITLE
Improve and simplify a test in client service 

### DIFF
--- a/client/service/examples/logger/logger/logger_test.go
+++ b/client/service/examples/logger/logger/logger_test.go
@@ -60,7 +60,7 @@ func TestListenError(t *testing.T) {
 
 	var resp errorResponse
 	require.Nil(t, execution.Data(&resp))
-	require.Contains(t, "json", resp.Message)
+	require.Contains(t, resp.Message, "json")
 }
 
 func TestClose(t *testing.T) {

--- a/client/service/examples/logger/logger/logger_test.go
+++ b/client/service/examples/logger/logger/logger_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mesg-foundation/core/client/service"
 	"github.com/mesg-foundation/core/client/service/servicetest"
-	"github.com/stvp/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const token = "token"
@@ -20,8 +20,8 @@ func newServiceAndServer(t *testing.T) (*service.Service, *servicetest.Server) {
 		service.TokenOption(token),
 		service.EndpointOption(endpoint),
 	)
-	assert.Nil(t, err)
-	assert.NotNil(t, s)
+	require.NoError(t, err)
+	require.NotNil(t, s)
 	return s, testServer
 }
 
@@ -38,12 +38,12 @@ func TestListenSuccess(t *testing.T) {
 	go logger.Start()
 
 	_, execution, err := server.Execute("log", data)
-	assert.Nil(t, err)
-	assert.Equal(t, "success", execution.Key())
+	require.NoError(t, err)
+	require.Equal(t, "success", execution.Key())
 
 	var resp successResponse
-	assert.Nil(t, execution.Data(&resp))
-	assert.Equal(t, "ok", resp.Message)
+	require.Nil(t, execution.Data(&resp))
+	require.Equal(t, "ok", resp.Message)
 }
 
 func TestListenError(t *testing.T) {
@@ -56,12 +56,12 @@ func TestListenError(t *testing.T) {
 	go logger.Start()
 
 	_, execution, err := server.Execute("log", data)
-	assert.Nil(t, err)
-	assert.Equal(t, "error", execution.Key())
+	require.NoError(t, err)
+	require.Equal(t, "error", execution.Key())
 
 	var resp errorResponse
-	assert.Nil(t, execution.Data(&resp))
-	assert.Contains(t, "json", resp.Message)
+	require.Nil(t, execution.Data(&resp))
+	require.Contains(t, "json", resp.Message)
 }
 
 func TestClose(t *testing.T) {
@@ -77,15 +77,15 @@ func TestClose(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert.Nil(t, logger.Start())
+		require.Nil(t, logger.Start())
 	}()
 
 	_, _, err := server.Execute("log", data)
-	assert.Nil(t, err)
-	assert.Nil(t, logger.Close())
+	require.NoError(t, err)
+	require.Nil(t, logger.Close())
 
 	_, _, err = server.Execute("log", data)
-	assert.Equal(t, servicetest.ErrConnectionClosed{}, err)
+	require.Equal(t, servicetest.ErrConnectionClosed{}, err)
 
 	wg.Wait()
 }

--- a/client/service/examples/logger/logger/logger_test.go
+++ b/client/service/examples/logger/logger/logger_test.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"io/ioutil"
-	"sync"
 	"testing"
 
 	"github.com/mesg-foundation/core/client/service"
@@ -71,14 +70,7 @@ func TestClose(t *testing.T) {
 	logger := New(s)
 
 	go server.Start()
-
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		require.Nil(t, logger.Start())
-	}()
+	go logger.Start()
 
 	_, _, err := server.Execute("log", data)
 	require.NoError(t, err)
@@ -86,6 +78,4 @@ func TestClose(t *testing.T) {
 
 	_, _, err = server.Execute("log", data)
 	require.Equal(t, servicetest.ErrConnectionClosed{}, err)
-
-	wg.Wait()
 }

--- a/client/service/service_test.go
+++ b/client/service/service_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/mesg-foundation/core/client/service/servicetest"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const token = "token"
@@ -29,8 +29,8 @@ func newServiceAndServer(t *testing.T) (*Service, *servicetest.Server) {
 		LogOutputOption(ioutil.Discard),
 	)
 
-	assert.Nil(t, err)
-	assert.NotNil(t, service)
+	require.NoError(t, err)
+	require.NotNil(t, service)
 
 	return service, testServer
 }
@@ -44,15 +44,15 @@ func TestEmit(t *testing.T) {
 	service, server := newServiceAndServer(t)
 	go server.Start()
 
-	go func() { assert.Nil(t, service.Emit(event, data)) }()
+	go func() { require.Nil(t, service.Emit(event, data)) }()
 	le := <-server.LastEmit()
 
-	assert.Equal(t, event, le.Name())
-	assert.Equal(t, token, le.Token())
+	require.Equal(t, event, le.Name())
+	require.Equal(t, token, le.Token())
 
 	var data1 eventRequest
-	assert.Nil(t, le.Data(&data1))
-	assert.Equal(t, data.URL, data1.URL)
+	require.Nil(t, le.Data(&data1))
+	require.Equal(t, data.URL, data1.URL)
 }
 
 type taskRequest struct {
@@ -83,23 +83,23 @@ func TestListen(t *testing.T) {
 		err := service.Listen(
 			Task(task, func(execution *Execution) (string, interface{}) {
 				var data2 taskRequest
-				assert.Nil(t, execution.Data(&data2))
-				assert.Equal(t, reqData.URL, data2.URL)
+				require.Nil(t, execution.Data(&data2))
+				require.Equal(t, reqData.URL, data2.URL)
 				return key, resData
 			}),
 		)
-		assert.True(t, err == nil || err == context.Canceled)
+		require.True(t, err == nil || err == context.Canceled)
 	}()
 
 	id, execution, err := server.Execute(task, reqData)
-	assert.Nil(t, err)
-	assert.Equal(t, id, execution.ID())
-	assert.Equal(t, key, execution.Key())
-	assert.Equal(t, token, server.ListenToken())
+	require.NoError(t, err)
+	require.Equal(t, id, execution.ID())
+	require.Equal(t, key, execution.Key())
+	require.Equal(t, token, server.ListenToken())
 
 	var data1 taskResponse
-	assert.Nil(t, execution.Data(&data1))
-	assert.Equal(t, resData.Message, data1.Message)
+	require.Nil(t, execution.Data(&data1))
+	require.Equal(t, resData.Message, data1.Message)
 
 	service.Close()
 	wg.Wait()
@@ -124,7 +124,7 @@ func TestMultipleListenCall(t *testing.T) {
 	server.Execute(taskKey, data)
 	<-makeSureListeningC
 
-	assert.Equal(t, service.Listen(taskable).Error(), errAlreadyListening{}.Error())
+	require.Equal(t, service.Listen(taskable).Error(), errAlreadyListening{}.Error())
 }
 
 func TestNonExistentTaskExecutionRequest(t *testing.T) {
@@ -149,6 +149,6 @@ func TestNonExistentTaskExecutionRequest(t *testing.T) {
 	go server.Execute(nonExistentTaskKey, data)
 
 	line, _, err := bufio.NewReader(reader).ReadLine()
-	assert.Nil(t, err)
-	assert.Contains(t, string(line), errNonExistentTask{name: nonExistentTaskKey}.Error())
+	require.NoError(t, err)
+	require.Contains(t, string(line), errNonExistentTask{name: nonExistentTaskKey}.Error())
 }

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/kevinburke/ssh_config v0.0.0-20180711164746-82cf3f926438 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kr/pty v1.1.3 // indirect
 	github.com/mattn/go-colorable v0.0.0-20180310133214-efa589957cd0 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect
@@ -58,7 +57,6 @@ require (
 	github.com/spf13/pflag v0.0.0-20180601132542-3ebe029320b2
 	github.com/src-d/gcfg v1.3.0 // indirect
 	github.com/stretchr/testify v1.3.0
-	github.com/stvp/assert v0.0.0-20170616060220-4bc16443988b
 	github.com/syndtr/goleveldb v0.0.0-20180708030551-c4c61651e9e3
 	github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5
 	github.com/xanzy/ssh-agent v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,13 +74,8 @@ github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kevinburke/ssh_config v0.0.0-20180711164746-82cf3f926438 h1:O2UbfXNOrED3WZ12PoAr2hYOb8hOXYyIHImqrEjkFGQ=
 github.com/kevinburke/ssh_config v0.0.0-20180711164746-82cf3f926438/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3 h1:/Um6a/ZmD5tF7peoOJ5oN5KMQ0DrGVQSXLNwyckutPk=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-colorable v0.0.0-20180310133214-efa589957cd0 h1:cDvUG90i1ssGJGqMNx2Ubbn+bx7VOzjdvQ45zpy0X4w=
 github.com/mattn/go-colorable v0.0.0-20180310133214-efa589957cd0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
@@ -131,8 +126,6 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stvp/assert v0.0.0-20170616060220-4bc16443988b h1:GlTM/aMVIwU3luIuSN2SIVRuTqGPt1P97YxAi514ulw=
-github.com/stvp/assert v0.0.0-20170616060220-4bc16443988b/go.mod h1:CC7OXV9IjEZRA+znA6/Kz5vbSwh69QioernOHeDCatU=
 github.com/syndtr/goleveldb v0.0.0-20180708030551-c4c61651e9e3 h1:sAlSBRDl4psFR3ysKXRSE8ss6Mt90+ma1zRTroTNBJA=
 github.com/syndtr/goleveldb v0.0.0-20180708030551-c4c61651e9e3/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5 h1:Xim2mBRFdXzXmKRO8DJg/FJtn/8Fj9NOEpO6+WuMPmk=


### PR DESCRIPTION
I simplify the test `TestClose` because CircleCI had a lots of problem to run it.. It worked on my computer but not most of the time on CircleCi:
https://circleci.com/gh/mesg-foundation/core/tree/feature%2Fclient-context