### PR TITLE
Update keep alive of client to 5min to prevent spamming the server

### DIFF
--- a/client/service/service.go
+++ b/client/service/service.go
@@ -78,7 +78,7 @@ type Option func(*Service)
 // New starts a new Service with options.
 func New(options ...Option) (*Service, error) {
 	dialKeepaliveOpt := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time: 1 * time.Minute,
+		Time: 5 * time.Minute,
 	})
 	s := &Service{
 		endpoint:     os.Getenv(endpointEnv),

--- a/interface/cli/main.go
+++ b/interface/cli/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	dialKeepaliveOpt := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time: 1 * time.Minute,
+		Time: 5 * time.Minute,
 	})
 	connection, err := grpc.Dial(cfg.Client.Address, dialKeepaliveOpt, grpc.WithInsecure())
 	if err != nil {

--- a/interface/grpc/server.go
+++ b/interface/grpc/server.go
@@ -53,13 +53,12 @@ func (s *Server) listen() (net.Listener, error) {
 		return nil, err
 	}
 
-	// keep-alive is need to prevent Docker network to think that gRPC connection is
-	// idle (see issues/549). without keep-alive it'll close the connection when there is
-	// no activity after some time. in that case grpc pkg will reconnect but all open
-	// gRPC streams needed to be re-established manually.
+	// keep-alive is need to prevent Docker network to think that gRPC connection is idle.
+	// See https://github.com/mesg-foundation/core/issues/549.
+	// Without keep-alive it'll close the connection when there is no activity after some time.
+	// In that case grpc pkg will reconnect but all open gRPC streams needed to be re-established manually.
 	//
-	// keep-alive needs to be lower than Docker network's timeout that gives the
-	// decions about idle connections.
+	// keep-alive needs to be lower than Docker network's timeout that gives the decions about idle connections.
 	keepaliveOpt := grpc.KeepaliveParams(keepalive.ServerParameters{
 		Time: 1 * time.Minute,
 	})


### PR DESCRIPTION
Related to https://github.com/mesg-foundation/core/issues/760 and https://github.com/mesg-foundation/core/issues/759

Client should not ping the server more often than the `EnforcementPolicy.MinTime` set on the server. By default it's 5min, so I set the client to ping the server every 5min.