### PR TITLE
Don't return error when stream header doesn't contains any status

### DIFF
--- a/protobuf/acknowledgement/stream.go
+++ b/protobuf/acknowledgement/stream.go
@@ -23,7 +23,7 @@ func WaitForStreamToBeReady(stream grpc.ClientStream) error {
 	statuses := header.Get(statusKey)
 	statusesLen := len(statuses)
 	if statusesLen == 0 {
-		return fmt.Errorf("stream header does not contain any status")
+		return nil // Ignore headers with no status key
 	}
 	lastStatus := statuses[statusesLen-1]
 	if lastStatus != statusReady {


### PR DESCRIPTION
The acknowledgement was returning an error when the stream header didn't contained `status`, thus overriding the error return by the stream..
The check are now eased to not return an error if header doesn't contains `status`.

It also prevent blocking the thread if the server doesn't implement acknowledgement header.