### PR TITLE
Update keep alive of client to 5min to prevent spamming the server

### DIFF
--- a/client/service/service.go
+++ b/client/service/service.go
@@ -80,7 +80,7 @@ type Option func(*Service)
 // New starts a new Service with options.
 func New(options ...Option) (*Service, error) {
 	dialKeepaliveOpt := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time: 1 * time.Minute,
+		Time: 5 * time.Minute,
 	})
 	s := &Service{
 		endpoint:     os.Getenv(endpointEnv),

--- a/client/service/service.go
+++ b/client/service/service.go
@@ -79,8 +79,10 @@ type Option func(*Service)
 
 // New starts a new Service with options.
 func New(options ...Option) (*Service, error) {
+	// Keep alive prevents Docker network to drop TCP idle connections after 15 minutes.
+	// See: https://forum.mesg.com/t/solution-summary-for-docker-dropping-connections-after-15-min/246
 	dialKeepaliveOpt := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time: 5 * time.Minute,
+		Time: 5 * time.Minute, // 5 minutes because it's the minimun time of gRPC enforcement policy.
 	})
 	s := &Service{
 		endpoint:     os.Getenv(endpointEnv),

--- a/interface/cli/main.go
+++ b/interface/cli/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	dialKeepaliveOpt := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time: 1 * time.Minute,
+		Time: 5 * time.Minute,
 	})
 	connection, err := grpc.Dial(cfg.Client.Address, dialKeepaliveOpt, grpc.WithInsecure())
 	if err != nil {

--- a/interface/cli/main.go
+++ b/interface/cli/main.go
@@ -25,8 +25,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Keep alive prevents Docker network to drop TCP idle connections after 15 minutes.
+	// See: https://forum.mesg.com/t/solution-summary-for-docker-dropping-connections-after-15-min/246
 	dialKeepaliveOpt := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time: 5 * time.Minute,
+		Time: 5 * time.Minute, // 5 minutes because it's the minimun time of gRPC enforcement policy.
 	})
 	connection, err := grpc.Dial(cfg.Client.Address, dialKeepaliveOpt, grpc.WithInsecure())
 	if err != nil {

--- a/interface/grpc/server.go
+++ b/interface/grpc/server.go
@@ -53,12 +53,8 @@ func (s *Server) listen() (net.Listener, error) {
 		return nil, err
 	}
 
-	// keep-alive is need to prevent Docker network to think that gRPC connection is idle.
-	// See https://github.com/mesg-foundation/core/issues/549.
-	// Without keep-alive it'll close the connection when there is no activity after some time.
-	// In that case grpc pkg will reconnect but all open gRPC streams needed to be re-established manually.
-	//
-	// keep-alive needs to be lower than Docker network's timeout that gives the decions about idle connections.
+	// Keep alive prevents Docker network to drop TCP idle connections after 15 minutes.
+	// See: https://forum.mesg.com/t/solution-summary-for-docker-dropping-connections-after-15-min/246
 	keepaliveOpt := grpc.KeepaliveParams(keepalive.ServerParameters{
 		Time: 1 * time.Minute,
 	})

--- a/interface/grpc/server.go
+++ b/interface/grpc/server.go
@@ -53,13 +53,12 @@ func (s *Server) listen() (net.Listener, error) {
 		return nil, err
 	}
 
-	// keep-alive is need to prevent Docker network to think that gRPC connection is
-	// idle (see issues/549). without keep-alive it'll close the connection when there is
-	// no activity after some time. in that case grpc pkg will reconnect but all open
-	// gRPC streams needed to be re-established manually.
+	// keep-alive is need to prevent Docker network to think that gRPC connection is idle.
+	// See https://github.com/mesg-foundation/core/issues/549.
+	// Without keep-alive it'll close the connection when there is no activity after some time.
+	// In that case grpc pkg will reconnect but all open gRPC streams needed to be re-established manually.
 	//
-	// keep-alive needs to be lower than Docker network's timeout that gives the
-	// decions about idle connections.
+	// keep-alive needs to be lower than Docker network's timeout that gives the decions about idle connections.
 	keepaliveOpt := grpc.KeepaliveParams(keepalive.ServerParameters{
 		Time: 1 * time.Minute,
 	})


### PR DESCRIPTION
Related to https://github.com/mesg-foundation/core/issues/760, https://github.com/mesg-foundation/core/issues/759 and https://github.com/mesg-foundation/core/pull/770

Client should not ping the server more often than the `EnforcementPolicy.MinTime` set on the server otherwise they get a GOAWAY error.
By default it's 5min, so I set the client to ping the server every 5min.

Also, by setting the client ping > to server ping, it also resolves the problem when both client and server were pigging themselve in both way. Now the client actually never has to ping the server if the connection is still open and the server pings the client.

This is a **critical fix** and needs to be released as soon as possible.