### PR TITLE
Support .mesgignore

### DIFF
--- a/commands/provider/service_publisher.go
+++ b/commands/provider/service_publisher.go
@@ -3,7 +3,10 @@ package provider
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 
+	"github.com/docker/docker/builder/dockerignore"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/mesg-foundation/core/ipfs"
 	"github.com/mesg-foundation/core/service/importer"
@@ -31,8 +34,15 @@ type marketplaceData struct {
 // ServicePublishDefinitionFile upload and publish the tarball and definition file and returns the address of the definition file
 func (p *ServiceProvider) ServicePublishDefinitionFile(path string) (string, error) {
 	ipfs := ipfs.New()
+
+	exclude, err := p.getExcludeList(path)
+	if err != nil {
+		return "", err
+	}
+
 	tar, err := archive.TarWithOptions(path, &archive.TarOptions{
-		Compression: archive.Gzip,
+		Compression:     archive.Gzip,
+		ExcludePatterns: exclude,
 	})
 	if err != nil {
 		return "", err
@@ -52,6 +62,18 @@ func (p *ServiceProvider) ServicePublishDefinitionFile(path string) (string, err
 		return "", err
 	}
 	return definitionResponse.Hash, nil
+}
+
+func (p *ServiceProvider) getExcludeList(path string) ([]string, error) {
+	f, err := os.Open(filepath.Join(path, ".mesgignore"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	return dockerignore.ReadAll(f)
 }
 
 func (p *ServiceProvider) createDefinitionFile(path string, tarballHash string) ([]byte, error) {


### PR DESCRIPTION
For publication on the marketplace we need to be able to ignore some files, `.dockerignore` can be confusing to use and maybe some files needs to be shared to the marketplace but not to the build in docker so this is the implementation for a `.mesgignore` that is dedicated to ignore files for publication like a `.npmignore` for example

based on this discussion https://github.com/mesg-foundation/core/pull/755#discussion_r252855613

depends on #755 