### PR TITLE
Stop services when core stop

### DIFF
--- a/commands/provider/core_provider.go
+++ b/commands/provider/core_provider.go
@@ -1,15 +1,11 @@
 package provider
 
 import (
-	"context"
 	"io"
-	"sync"
 
 	"github.com/mesg-foundation/core/container"
 	"github.com/mesg-foundation/core/daemon"
 	"github.com/mesg-foundation/core/protobuf/coreapi"
-	"github.com/mesg-foundation/core/service"
-	"github.com/mesg-foundation/core/x/xerrors"
 )
 
 // CoreProvider is a struct that provides all methods required by core command.
@@ -33,43 +29,7 @@ func (p *CoreProvider) Start() error {
 
 // Stop stops core daemon and all running services.
 func (p *CoreProvider) Stop() error {
-	ids, err := service.ListRunning()
-	if err != nil {
-		return err
-	}
-
-	var (
-		idsLen = len(ids)
-		errC   = make(chan error, idsLen)
-		wg     sync.WaitGroup
-	)
-
-	wg.Add(idsLen)
-	for _, id := range ids {
-		go func(id string) {
-			defer wg.Done()
-			_, err := p.client.StopService(context.Background(), &coreapi.StopServiceRequest{
-				ServiceID: id,
-			})
-			if err != nil {
-				errC <- err
-			}
-		}(id)
-	}
-
-	wg.Wait()
-	close(errC)
-
-	var errs xerrors.Errors
-	for err := range errC {
-		errs = append(errs, err)
-	}
-
-	if err := p.d.Stop(); err != nil {
-		errs = append(errs, err)
-	}
-
-	return errs.ErrorOrNil()
+	return p.d.Stop()
 }
 
 // Status returns daemon status.

--- a/core/main.go
+++ b/core/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mesg-foundation/core/database"
 	"github.com/mesg-foundation/core/interface/grpc"
 	"github.com/mesg-foundation/core/logger"
-	"github.com/mesg-foundation/core/service"
 	"github.com/mesg-foundation/core/version"
 	"github.com/mesg-foundation/core/x/xsignal"
 	"github.com/sirupsen/logrus"
@@ -80,14 +79,8 @@ func stopRunningServices(api *api.API) error {
 		return err
 	}
 	for _, s := range services {
-		status, err := s.Status()
-		if err != nil {
+		if err := api.StopService(s.Hash); err != nil {
 			return err
-		}
-		if status == service.STARTING || status == service.PARTIAL || status == service.RUNNING {
-			if err := api.StopService(s.Hash); err != nil {
-				return err
-			}
 		}
 	}
 	return nil

--- a/core/main.go
+++ b/core/main.go
@@ -22,37 +22,36 @@ type dependencies struct {
 }
 
 func initDependencies() (*dependencies, error) {
-	dep := dependencies{}
-
 	// init configs.
 	config, err := config.Global()
 	if err != nil {
-		return &dep, err
+		return nil, err
 	}
-	dep.config = config
 
 	// init services db.
-	serviceDB, err := database.NewServiceDB(filepath.Join(dep.config.Core.Path, dep.config.Core.Database.ServiceRelativePath))
+	serviceDB, err := database.NewServiceDB(filepath.Join(config.Core.Path, config.Core.Database.ServiceRelativePath))
 	if err != nil {
-		return &dep, err
+		return nil, err
 	}
-	dep.serviceDB = serviceDB
 
 	// init execution db.
-	executionDB, err := database.NewExecutionDB(filepath.Join(dep.config.Core.Path, dep.config.Core.Database.ExecutionRelativePath))
+	executionDB, err := database.NewExecutionDB(filepath.Join(config.Core.Path, config.Core.Database.ExecutionRelativePath))
 	if err != nil {
-		return &dep, err
+		return nil, err
 	}
-	dep.executionDB = executionDB
 
 	// init api.
-	api, err := api.New(dep.serviceDB, dep.executionDB)
+	api, err := api.New(serviceDB, executionDB)
 	if err != nil {
-		return &dep, err
+		return nil, err
 	}
-	dep.api = api
 
-	return &dep, nil
+	return &dependencies{
+		config:      config,
+		serviceDB:   serviceDB,
+		executionDB: executionDB,
+		api:         api,
+	}, nil
 }
 
 func deployCoreServices(config *config.Config, api *api.API) error {


### PR DESCRIPTION
Right now we rely on the CLI to stop all service before stoping the core. This is not really nice and create issues if we stop the core with another CLI (`docker service rm` for exemple).

When the Core stops, it will stop all the running services, close the api and then exit. 