### PR TITLE
Deterministic hash - refactor and fix deployment

### DIFF
--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -105,13 +105,8 @@ func TestDeployServiceFromURL(t *testing.T) {
 	}()
 
 	require.Equal(t, DeployStatus{
-		Message: "Downloading service...",
+		Message: "Receiving service context...",
 		Type:    Running,
-	}, <-statuses)
-
-	require.Equal(t, DeployStatus{
-		Message: "Service downloaded with success",
-		Type:    DonePositive,
 	}, <-statuses)
 
 	require.Equal(t, DeployStatus{


### PR DESCRIPTION
Fix for https://github.com/mesg-foundation/core/pull/731

After a long time trying to go deep on why the hash was different between git and the tarball from github and our tarball I found out 2 things:

- Git override the date of creation, what @krhubert already saw and fixed with this 
```go
filepath.Walk(path, func(p string, fi os.FileInfo, _ error) error {
	return os.Chtimes(p, time.Time{}, time.Time{})
})
```
- The tarball had different file permissions than the git
```
GIT:
DEBU[0011] /package.json  IsDir=false ModTime="2019-03-08 16:24:12.514313 +0000 UTC" Mode=-rw-r--r-- Name=package.json Size=364
TARBALL:
DEBU[0028] /package.json  IsDir=false ModTime="2019-01-22 05:18:44 +0000 UTC"        Mode=-rw-rw-r-- Name=package.json Size=364
```

The docker untar function we used was the cause so I wrote a function to untar directly the content without the extra work that docker needs (here we don't care about docker).

I also did some refactoring on the `FromArchive/FromURL` function to have the url that uses the untar system and the tarball received is also untared to make sure the process is the same whatever the source of deployment and with all that now everything works fine

Here are some manual tests
```
./dev-cli service deploy https://github.com/mesg-foundation/service-webhook
> f4af4efd2c11e25655d41eb8ef10aa4d0abc2dda008249bc691f0cabc0b06cc4

./dev-cli service deploy https://api.github.com/repos/mesg-foundation/service-webhook/tarball/master
> f4af4efd2c11e25655d41eb8ef10aa4d0abc2dda008249bc691f0cabc0b06cc4

./dev-cli service deploy service-webhook
> f4af4efd2c11e25655d41eb8ef10aa4d0abc2dda008249bc691f0cabc0b06cc4


./dev-cli service deploy https://github.com/mesg-foundation/service-ethereum/archive/master.tar.gz
> 89961e225f1526f324d568e24f9f05849d0211451d4fb4581fddf25d4188c20c

./dev-cli service deploy https://github.com/mesg-foundation/service-ethereum
> 89961e225f1526f324d568e24f9f05849d0211451d4fb4581fddf25d4188c20c

./dev-cli service deploy service-ethereum/
> 89961e225f1526f324d568e24f9f05849d0211451d4fb4581fddf25d4188c20c
```

Feel free to test it yourself and verify that you get the same hashes