### PR TITLE
Fix container package

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -45,6 +45,9 @@ type DockerContainer struct {
 	// callTimeout is the timeout value for Docker API calls.
 	callTimeout time.Duration
 
+	// defaultStopGracePeriod is the timeout value between stopping a container and killing it.
+	defaultStopGracePeriod time.Duration
+
 	config *config.Config
 }
 
@@ -54,7 +57,8 @@ type Option func(*DockerContainer)
 // New creates a new Container with given options.
 func New(options ...Option) (*DockerContainer, error) {
 	c := &DockerContainer{
-		callTimeout: 10 * time.Second,
+		callTimeout:            60 * time.Second,
+		defaultStopGracePeriod: 10 * time.Second, // default docker value
 	}
 	for _, option := range options {
 		option(c)

--- a/container/container.go
+++ b/container/container.go
@@ -21,7 +21,7 @@ var (
 type Container interface {
 	Build(path string) (tag string, err error)
 	CreateNetwork(namespace []string) (id string, err error)
-	DeleteNetwork(namespace []string, event EventType) error
+	DeleteNetwork(namespace []string) error
 	FindContainer(namespace []string) (types.ContainerJSON, error)
 	FindNetwork(namespace []string) (types.NetworkResource, error)
 	FindService(namespace []string) (swarm.Service, error)

--- a/container/mocks/Container.go
+++ b/container/mocks/Container.go
@@ -55,13 +55,13 @@ func (_m *Container) CreateNetwork(namespace []string) (string, error) {
 	return r0, r1
 }
 
-// DeleteNetwork provides a mock function with given fields: namespace, event
-func (_m *Container) DeleteNetwork(namespace []string, event container.EventType) error {
-	ret := _m.Called(namespace, event)
+// DeleteNetwork provides a mock function with given fields: namespace
+func (_m *Container) DeleteNetwork(namespace []string) error {
+	ret := _m.Called(namespace)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func([]string, container.EventType) error); ok {
-		r0 = rf(namespace, event)
+	if rf, ok := ret.Get(0).(func([]string) error); ok {
+		r0 = rf(namespace)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/container/network_integration_test.go
+++ b/container/network_integration_test.go
@@ -12,7 +12,7 @@ func TestIntegrationCreateNetwork(t *testing.T) {
 	c, err := New()
 	require.NoError(t, err)
 	networkID, err := c.CreateNetwork([]string{"TestCreateNetwork"})
-	defer c.DeleteNetwork([]string{"TestCreateNetwork"}, EventRemove)
+	defer c.DeleteNetwork([]string{"TestCreateNetwork"})
 	require.NoError(t, err)
 	require.NotEqual(t, "", networkID)
 }
@@ -22,7 +22,7 @@ func TestIntegrationCreateAlreadyExistingNetwork(t *testing.T) {
 	require.NoError(t, err)
 	c.CreateNetwork([]string{"TestCreateAlreadyExistingNetwork"})
 	networkID, err := c.CreateNetwork([]string{"TestCreateAlreadyExistingNetwork"})
-	defer c.DeleteNetwork([]string{"TestCreateAlreadyExistingNetwork"}, EventRemove)
+	defer c.DeleteNetwork([]string{"TestCreateAlreadyExistingNetwork"})
 	require.NoError(t, err)
 	require.NotEqual(t, "", networkID)
 }
@@ -31,14 +31,14 @@ func TestIntegrationDeleteNetwork(t *testing.T) {
 	c, err := New()
 	require.NoError(t, err)
 	c.CreateNetwork([]string{"TestDeleteNetwork"})
-	err = c.DeleteNetwork([]string{"TestDeleteNetwork"}, EventRemove)
+	err = c.DeleteNetwork([]string{"TestDeleteNetwork"})
 	require.NoError(t, err)
 }
 
 func TestIntegrationDeleteNotExistingNetwork(t *testing.T) {
 	c, err := New()
 	require.NoError(t, err)
-	err = c.DeleteNetwork([]string{"TestDeleteNotExistingNetwork"}, EventRemove)
+	err = c.DeleteNetwork([]string{"TestDeleteNotExistingNetwork"})
 	require.NoError(t, err)
 }
 
@@ -46,7 +46,7 @@ func TestIntegrationFindNetwork(t *testing.T) {
 	c, err := New()
 	require.NoError(t, err)
 	c.CreateNetwork([]string{"TestFindNetwork"})
-	defer c.DeleteNetwork([]string{"TestFindNetwork"}, EventRemove)
+	defer c.DeleteNetwork([]string{"TestFindNetwork"})
 	network, err := c.FindNetwork([]string{"TestFindNetwork"})
 	require.NoError(t, err)
 	require.NotEqual(t, "", network.ID)
@@ -63,7 +63,7 @@ func TestIntegrationFindDeletedNetwork(t *testing.T) {
 	c, err := New()
 	require.NoError(t, err)
 	c.CreateNetwork([]string{"TestFindDeletedNetwork"})
-	c.DeleteNetwork([]string{"TestFindDeletedNetwork"}, EventRemove)
+	c.DeleteNetwork([]string{"TestFindDeletedNetwork"})
 	_, err = c.FindNetwork([]string{"TestFindDeletedNetwork"})
 	require.Error(t, err)
 }

--- a/container/network_test.go
+++ b/container/network_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/events"
 	"github.com/mesg-foundation/core/container/dockertest"
 	"github.com/stretchr/testify/require"
 )
@@ -74,18 +73,14 @@ func TestDeleteNetwork(t *testing.T) {
 	dt := dockertest.New()
 	c, _ := New(ClientOption(dt.Client()))
 
-	msgC := make(chan events.Message, 1)
-	errC := make(chan error)
-	dt.ProvideEvents(msgC, errC)
-	msgC <- events.Message{ID: id}
-
 	// discard network requests made from New.
 	<-dt.LastNetworkInspect()
 	<-dt.LastNetworkCreate()
 
 	dt.ProvideNetworkInspect(types.NetworkResource{ID: id}, nil)
+	dt.ProvideNetworkInspect(types.NetworkResource{}, dockertest.NotFoundErr{})
 
-	require.Nil(t, c.DeleteNetwork(namespace, EventRemove))
+	require.Nil(t, c.DeleteNetwork(namespace))
 
 	li := <-dt.LastNetworkInspect()
 	require.Equal(t, c.Namespace(namespace), li.Network)
@@ -106,7 +101,7 @@ func TestDeleteNotExistingNetwork(t *testing.T) {
 
 	dt.ProvideNetworkInspect(types.NetworkResource{}, dockertest.NotFoundErr{})
 
-	require.Nil(t, c.DeleteNetwork(namespace, EventRemove))
+	require.Nil(t, c.DeleteNetwork(namespace))
 
 	select {
 	case <-dt.LastNetworkRemove():
@@ -129,7 +124,7 @@ func TestDeleteNetworkError(t *testing.T) {
 
 	dt.ProvideNetworkInspect(types.NetworkResource{}, errNetworkDelete)
 
-	require.NotNil(t, c.DeleteNetwork(namespace, EventRemove))
+	require.NotNil(t, c.DeleteNetwork(namespace))
 }
 
 func TestFindNetwork(t *testing.T) {

--- a/container/service.go
+++ b/container/service.go
@@ -67,8 +67,6 @@ func (c *DockerContainer) StopService(namespace []string) error {
 	if status == STOPPED {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), c.callTimeout)
-	defer cancel()
 	service, err := c.FindService(namespace)
 	if err != nil && !docker.IsErrNotFound(err) {
 		return err
@@ -77,7 +75,7 @@ func (c *DockerContainer) StopService(namespace []string) error {
 	if service.Spec.TaskTemplate.ContainerSpec != nil && service.Spec.TaskTemplate.ContainerSpec.StopGracePeriod != nil {
 		stopGracePeriod = *service.Spec.TaskTemplate.ContainerSpec.StopGracePeriod
 	}
-	ctx, cancel = context.WithTimeout(context.Background(), c.callTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.callTimeout)
 	defer cancel()
 	if err := c.client.ServiceRemove(ctx, c.Namespace(namespace)); err != nil && !docker.IsErrNotFound(err) {
 		return err

--- a/container/service.go
+++ b/container/service.go
@@ -67,38 +67,46 @@ func (c *DockerContainer) StopService(namespace []string) error {
 	if status == STOPPED {
 		return nil
 	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), c.callTimeout)
+	defer cancel()
+	service, err := c.FindService(namespace)
+	if err != nil && !docker.IsErrNotFound(err) {
+		return err
+	}
+	stopGracePeriod := c.defaultStopGracePeriod
+	if service.Spec.TaskTemplate.ContainerSpec != nil && service.Spec.TaskTemplate.ContainerSpec.StopGracePeriod != nil {
+		stopGracePeriod = *service.Spec.TaskTemplate.ContainerSpec.StopGracePeriod
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), c.callTimeout)
 	defer cancel()
 	if err := c.client.ServiceRemove(ctx, c.Namespace(namespace)); err != nil && !docker.IsErrNotFound(err) {
 		return err
 	}
-	if err := c.deletePendingContainer(namespace); err != nil {
+	if err := c.deletePendingContainer(namespace, time.Now().Add(stopGracePeriod)); err != nil {
 		return err
 	}
 	return c.waitForStatus(namespace, STOPPED)
 }
 
-func (c *DockerContainer) deletePendingContainer(namespace []string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), c.callTimeout)
-	defer cancel()
+func (c *DockerContainer) deletePendingContainer(namespace []string, maxGraceTime time.Time) error {
 	container, err := c.FindContainer(namespace)
+	if docker.IsErrNotFound(err) {
+		return nil
+	}
 	if err != nil {
-		if docker.IsErrNotFound(err) {
-			return nil
-		}
 		return err
 	}
-	// TOFIX: Hack to force Docker to remove the containers.
-	// Sometime, the ServiceRemove function doesn't remove the associated containers.
+	// Hack to force Docker to remove the containers.
+	// Sometime, the ServiceRemove function doesn't remove the associated containers, or too late and the Core cannot remove the associated networks.
 	// This hack for Docker to stop and then remove the container.
 	// See issue https://github.com/moby/moby/issues/32620
-	if container.ContainerJSONBase != nil {
-		timeout := 1 * time.Second
-		c.client.ContainerStop(ctx, container.ID, &timeout)
-		c.client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{})
+	if time.Now().After(maxGraceTime) {
+		ctx, cancel := context.WithTimeout(context.Background(), c.callTimeout)
+		defer cancel()
+		c.client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true})
 	}
-	return c.deletePendingContainer(namespace)
+	time.Sleep(1 * time.Second)
+	return c.deletePendingContainer(namespace, maxGraceTime)
 }
 
 // ServiceLogs returns the logs of a service.

--- a/container/service_options.go
+++ b/container/service_options.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/swarm"
@@ -11,15 +12,16 @@ import (
 
 // ServiceOptions is a simplify version of swarm.ServiceSpec.
 type ServiceOptions struct {
-	Image     string
-	Namespace []string
-	Ports     []Port
-	Mounts    []Mount
-	Env       []string // TODO: should be transform to  map[string]string and use the func mapToEnv
-	Args      []string
-	Command   string
-	Networks  []Network
-	Labels    map[string]string
+	Image           string
+	Namespace       []string
+	Ports           []Port
+	Mounts          []Mount
+	Env             []string // TODO: should be transform to  map[string]string and use the func mapToEnv
+	Args            []string
+	Command         string
+	Networks        []Network
+	Labels          map[string]string
+	StopGracePeriod *time.Duration
 }
 
 // Network keeps the network info for service.
@@ -61,10 +63,11 @@ func (options *ServiceOptions) toSwarmServiceSpec(c *DockerContainer) swarm.Serv
 				Labels: map[string]string{
 					"com.docker.stack.namespace": namespace,
 				},
-				Env:     options.Env,
-				Args:    options.Args,
-				Command: strings.Fields(options.Command),
-				Mounts:  options.swarmMounts(false),
+				Env:             options.Env,
+				Args:            options.Args,
+				Command:         strings.Fields(options.Command),
+				Mounts:          options.swarmMounts(false),
+				StopGracePeriod: options.StopGracePeriod,
 			},
 			Networks: options.swarmNetworks(),
 		},

--- a/container/shared_network.go
+++ b/container/shared_network.go
@@ -24,11 +24,9 @@ func (c *DockerContainer) createSharedNetworkIfNeeded() error {
 	if network.ID != "" {
 		return nil
 	}
-
+	// Create the new network needed to run containers.
 	ctx, cancel := context.WithTimeout(context.Background(), c.callTimeout)
 	defer cancel()
-
-	// Create the new network needed to run containers.
 	namespace := c.Namespace([]string{})
 	_, err = c.client.NetworkCreate(ctx, namespace, types.NetworkCreate{
 		CheckDuplicate: true,

--- a/container/wait_integration_test.go
+++ b/container/wait_integration_test.go
@@ -40,5 +40,5 @@ func TestIntegrationWaitForStatusTaskError(t *testing.T) {
 	defer c.StopService(namespace)
 	err = c.waitForStatus(namespace, RUNNING)
 	require.Error(t, err)
-	require.Contains(t, "No such image: awgdaywudaywudwa:latest", err.Error())
+	require.Contains(t, err.Error(), "No such image: awgdaywudaywudwa:latest")
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"io"
+	"time"
 
 	"github.com/mesg-foundation/core/config"
 	"github.com/mesg-foundation/core/container"
@@ -58,6 +59,7 @@ func (d *ContainerDaemon) Logs() (io.ReadCloser, error) {
 
 func (d *ContainerDaemon) buildServiceOptions(sharedNetworkID string) container.ServiceOptions {
 	_, port, _ := xnet.SplitHostPort(d.cfg.Server.Address)
+	stopGracePeriod := 60 * time.Second
 	return container.ServiceOptions{
 		Namespace: []string{},
 		Image:     d.cfg.Core.Image,
@@ -83,5 +85,6 @@ func (d *ContainerDaemon) buildServiceOptions(sharedNetworkID string) container.
 		Networks: []container.Network{
 			{ID: sharedNetworkID},
 		},
+		StopGracePeriod: &stopGracePeriod,
 	}
 }

--- a/service/start_integration_test.go
+++ b/service/start_integration_test.go
@@ -118,7 +118,7 @@ func TestIntegrationStartDependency(t *testing.T) {
 	}, ContainerOption(c))
 	networkID, err := c.CreateNetwork(service.namespace())
 	require.NoError(t, err)
-	defer c.DeleteNetwork(service.namespace(), container.EventDestroy)
+	defer c.DeleteNetwork(service.namespace())
 	dep := service.Dependencies[0]
 	serviceID, err := dep.Start(networkID)
 	defer dep.Stop()

--- a/service/stop.go
+++ b/service/stop.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"sync"
-
-	"github.com/mesg-foundation/core/container"
 )
 
 // Stop stops a service.
@@ -16,7 +14,7 @@ func (s *Service) Stop() error {
 	if err := s.StopDependencies(); err != nil {
 		return err
 	}
-	return s.container.DeleteNetwork(s.namespace(), container.EventDestroy)
+	return s.container.DeleteNetwork(s.namespace())
 }
 
 // StopDependencies stops all dependencies.

--- a/service/stop_integration_test.go
+++ b/service/stop_integration_test.go
@@ -58,7 +58,7 @@ func TestIntegrationStopDependency(t *testing.T) {
 	}, ContainerOption(c))
 	networkID, err := c.CreateNetwork(service.namespace())
 	require.NoError(t, err)
-	defer c.DeleteNetwork(service.namespace(), container.EventDestroy)
+	defer c.DeleteNetwork(service.namespace())
 	dep := service.Dependencies[0]
 	dep.Start(networkID)
 	err = dep.Stop()

--- a/service/stop_test.go
+++ b/service/stop_test.go
@@ -25,7 +25,7 @@ func TestStopRunningService(t *testing.T) {
 
 	mc.On("Status", d.namespace()).Once().Return(container.RUNNING, nil)
 	mc.On("StopService", d.namespace()).Once().Return(nil)
-	mc.On("DeleteNetwork", s.namespace(), container.EventDestroy).Once().Return(nil)
+	mc.On("DeleteNetwork", s.namespace()).Once().Return(nil)
 
 	err := s.Stop()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR fixes and simplifies a few stuff on the package container:

- Introduce the option StopGracePeriod.
This option tells docker the time to wait between the service is removed and killing the associated container. Now it's possible to set a custom on when starting a docker service.

- Upgrade function `deletePendingContainer` to wait for a grace period before removing the container.
It will either use the grace period is set in the docker service data or use the default one (10sec) if the first is not set.
The previous logic of `deletePendingContainer` was killing and removing the container after only a few second, without anyway to change the time (timeout of containerStop was somehow not taking into account, maybe because of docker service).

- Simplifying / improving function `DeleteNetwork`.
The `DeleteNetwork` was using Docker.Events function to listen for network deletion event with a context with timeout. The problem is, sometime, the network is deleted either too early or too late (after the context timeout), so the `DeleteNetwork` was falling in such case.
I update the code to use a similar logic that the function `deletePendingContainer`, a recursive call that check if the network is actually deleted first.

- Change default `container.callTimeout` to 60sec.