### PR TITLE
fix inheritance in yaml for the marketplace

### DIFF
--- a/systemservices/marketplace/mesg.yml
+++ b/systemservices/marketplace/mesg.yml
@@ -234,11 +234,11 @@ tasks:
     description: ""
     inputs:
       sid:
-        optional: true
         <<: *sid
-      versionHash:
         optional: true
+      versionHash:
         <<: *versionHash
+        optional: true
       addresses:
         name: ""
         description: ""


### PR DESCRIPTION
Small PR to fix some potential issues with inheritance in the mesg.yml from the marketplace.
Inherits first then override instead of define first and inherits (the inheritance could override the defined attributes)