### PR TITLE
Marketplace service new api for manifest

### DIFF
--- a/systemservices/marketplace/mesg.yml
+++ b/systemservices/marketplace/mesg.yml
@@ -51,16 +51,18 @@ tasks:
                   manifest: &manifest
                     name: ""
                     description: ""
-                    type: String
-                  manifestProtocol: &manifestProtocol
-                    name: ""
-                    description: ""
-                    type: String
-                  manifestData: &manifestData
-                    name: ""
-                    description: ""
                     type: Object
                     optional: true
+                    object: 
+                      version: { type: String }
+                      service:
+                        hash: { type: String }
+                        hashVersion: { type: String }
+                        deployment:
+                          type: { type: String }
+                          source: { type: String }
+                        definition: { type: Object }
+                        readme: { type: String }
                   createTime: *createTime
               offers: &offers
                 name: ""
@@ -130,9 +132,14 @@ tasks:
     name: ""
     description: ""
     inputs:
-      sid: *sid
-      manifest: *manifest
-      manifestProtocol: *manifestProtocol
+      service:
+        hash: { type: String }
+        hashVersion: { type: String }
+        deployment:
+          type: { type: String }
+          source: { type: String }
+        definition: { type: Object }
+        readme: { type: String }
       from: &inputFrom
         name: ""
         description: ""

--- a/systemservices/marketplace/src/contracts/version.ts
+++ b/systemservices/marketplace/src/contracts/version.ts
@@ -29,12 +29,10 @@ const getServiceVersion = async (contract: Marketplace, versionHash: string): Pr
     return
   }
   const version = await contract.methods.serviceVersion(versionHashHex).call()
-  const manifestData = await getManifest(hexToAscii(version.manifestProtocol), hexToAscii(version.manifest))
+  const manifest = await getManifest(hexToAscii(version.manifestProtocol), hexToAscii(version.manifest))
   return {
     versionHash: versionHash,
-    manifest: hexToAscii(version.manifest),
-    manifestProtocol: hexToAscii(version.manifestProtocol),
-    manifestData: manifestData,
+    manifest: manifest,
     createTime: parseTimestamp(version.createTime),
   }
 }

--- a/systemservices/marketplace/src/tasks/publishServiceVersion.ts
+++ b/systemservices/marketplace/src/tasks/publishServiceVersion.ts
@@ -1,16 +1,21 @@
 import { TaskInputs, TaskOutputs } from "mesg-js/lib/service"
 import { Marketplace } from "../contracts/Marketplace"
 import { asciiToHex, CreateTransaction, hashToHex } from "../contracts/utils";
+import { Manifest } from "../types/manifest";
 
 export default (
   marketplace: Marketplace,
   createTransaction: CreateTransaction
 ) => async (inputs: TaskInputs, outputs: TaskOutputs): Promise<void> => {
   try {
+    const manifestHash = await uploadManifest({
+      version: '1',
+      service: inputs.service
+    })
     const transactionData = marketplace.methods.publishServiceVersion(
       asciiToHex(inputs.sid),
-      asciiToHex(inputs.manifest),
-      asciiToHex(inputs.manifestProtocol)
+      asciiToHex(manifestHash),
+      asciiToHex('IPFS')
     ).encodeABI()
     return outputs.success(await createTransaction(marketplace, inputs, transactionData))
   }
@@ -18,4 +23,15 @@ export default (
     console.error('error in publishServiceVersion', error)
     return outputs.error({ message: error.toString() })
   }
+}
+
+const uploadManifest = async (manifest: Manifest): Promise<string> => {
+  const ipfsClient = require('ipfs-http-client')
+  const IPFS = ipfsClient('ipfs.infura.io', '5001', {protocol: 'https'})
+  const buffer = Buffer.from(JSON.stringify(manifest))
+  const res = await IPFS.add(buffer, {pin: false})
+  if (!res.length) {
+    throw new Error('Error while uploading manifest')
+  }
+  return res[0].hash
 }

--- a/systemservices/marketplace/src/types/version.ts
+++ b/systemservices/marketplace/src/types/version.ts
@@ -2,8 +2,6 @@ import { Manifest } from "./manifest";
 
 export interface Version {
   versionHash: string;
-  manifest: string;
-  manifestProtocol: string;
-  manifestData: Manifest|undefined;
+  manifest: Manifest|undefined;
   createTime: Date;
 }


### PR DESCRIPTION
The goal here is to add validation of the manifest data directly with the core by passing all arguments necessary to the service and giving responsibility to the service to manage how it wants to upload this manifest (with IPFS or whatever).

This remove a lot of logic from the client and also remove the management of version from the client, now the service manages the version (we change the service == we change the version).

The client doesn't need to know anything about how data are stored in the marketplace IPFS or no. For now we still need to upload the sources but ultimately we should even give directly the tarball to the system service and let it handle everything

@NicolasMahe want to have your feedback before I continue to make sure that this is aligned with what you want with https://github.com/mesg-foundation/core/pull/829 and https://github.com/mesg-foundation/core/pull/835