### PR TITLE
One sid has one hash

### DIFF
--- a/database/service_db.go
+++ b/database/service_db.go
@@ -178,6 +178,12 @@ func (d *LevelDBServiceDB) Save(s *service.Service) error {
 		return err
 	}
 
+	// delete existent service that has the same sid.
+	if err := d.delete(tx, s.Sid); err != nil && !IsErrNotFound(err) {
+		tx.Discard()
+		return err
+	}
+
 	// encode service
 	b, err := d.marshal(s)
 	if err != nil {


### PR DESCRIPTION
The PR https://github.com/mesg-foundation/core/pull/764 was not completed so the service database had inconsistencies. It was possible to have multiple identical sid in the database also some services were not accessible with the sid after a newest version was delete.

Reverting back to initial behavior which is:
One sid **has one** hash
One hash **belongs to** one sid

This will be later changed to
One sid **has many** hashes
One hash **belongs to** one sid