### PR TITLE
Tag image built

### DIFF
--- a/container/build_integration_test.go
+++ b/container/build_integration_test.go
@@ -14,7 +14,7 @@ func TestIntegrationBuild(t *testing.T) {
 	tag, err := c.Build("test/", "test", "x1")
 	require.NoError(t, err)
 	require.NotEqual(t, "", tag)
-	require.Equal(t, "test:x1", tag)
+	require.Equal(t, "mesg/test:x1", tag)
 }
 
 func TestIntegrationBuildNotWorking(t *testing.T) {

--- a/container/build_integration_test.go
+++ b/container/build_integration_test.go
@@ -11,22 +11,22 @@ import (
 func TestIntegrationBuild(t *testing.T) {
 	c, err := New()
 	require.NoError(t, err)
-	tag, err := c.Build("test/")
+	tag, err := c.Build("test/", "test", "x1")
 	require.NoError(t, err)
 	require.NotEqual(t, "", tag)
+	require.Equal(t, "test:x1", tag)
 }
 
 func TestIntegrationBuildNotWorking(t *testing.T) {
 	c, err := New()
 	require.NoError(t, err)
-	tag, err := c.Build("test-not-valid/")
+	_, err = c.Build("test-not-valid/", "test", "x2")
 	require.Error(t, err)
-	require.Equal(t, "", tag)
 }
 
 func TestIntegrationBuildWrongPath(t *testing.T) {
 	c, err := New()
 	require.NoError(t, err)
-	_, err = c.Build("testss/")
+	_, err = c.Build("testss/", "test", "x3")
 	require.Error(t, err)
 }

--- a/container/build_test.go
+++ b/container/build_test.go
@@ -22,11 +22,12 @@ func newImageBuildResponse(body string) types.ImageBuildResponse {
 
 func TestBuild(t *testing.T) {
 	var (
-		expectedTag = "sha256:1f6359c933421f53a7ef9e417bfa51b1c313c54878fdeb16de827f427e16d836"
+		expectedTag = "foo:bar"
 		options     = types.ImageBuildOptions{
 			Remove:         true,
 			ForceRemove:    true,
 			SuppressOutput: true,
+			Tags:           []string{"foo:bar"},
 		}
 		c, m = newTesting(t)
 	)

--- a/container/build_test.go
+++ b/container/build_test.go
@@ -22,12 +22,12 @@ func newImageBuildResponse(body string) types.ImageBuildResponse {
 
 func TestBuild(t *testing.T) {
 	var (
-		expectedTag = "foo:bar"
+		expectedTag = "test:x"
 		options     = types.ImageBuildOptions{
 			Remove:         true,
 			ForceRemove:    true,
 			SuppressOutput: true,
-			Tags:           []string{"foo:bar"},
+			Tags:           []string{expectedTag},
 		}
 		c, m = newTesting(t)
 	)
@@ -99,8 +99,7 @@ func TestBuildResponseError(t *testing.T) {
 
 	m.On("ImageBuild", imageBuildArguments...).Once().Return(imageBuildResponse...).Run(imageBuildRun)
 
-	tag, err := c.Build(path, "test", "x")
-	require.Empty(t, tag)
+	_, err := c.Build(path, "test", "x")
 	require.Equal(t, "image build failed. invalid reference format: repository name must be lowercase", err.Error())
 
 	m.AssertExpectations(t)

--- a/container/build_test.go
+++ b/container/build_test.go
@@ -68,7 +68,7 @@ func TestBuild(t *testing.T) {
 
 	m.On("ImageBuild", imageBuildArguments...).Once().Return(imageBuildResponse...).Run(imageBuildRun)
 
-	tag, err := c.Build("test/")
+	tag, err := c.Build("test/", "test", "x")
 	require.NoError(t, err)
 	require.Equal(t, expectedTag, tag)
 
@@ -98,7 +98,7 @@ func TestBuildResponseError(t *testing.T) {
 
 	m.On("ImageBuild", imageBuildArguments...).Once().Return(imageBuildResponse...).Run(imageBuildRun)
 
-	tag, err := c.Build(path)
+	tag, err := c.Build(path, "test", "x")
 	require.Empty(t, tag)
 	require.Equal(t, "image build failed. invalid reference format: repository name must be lowercase", err.Error())
 
@@ -124,14 +124,13 @@ func TestBuildWrongPath(t *testing.T) {
 
 	m.On("ImageBuild", imageBuildArguments...).Once().Return(imageBuildResponse...).Run(imageBuildRun)
 
-	_, err := c.Build("testss/")
+	_, err := c.Build("testss/", "test", "x")
 	require.Equal(t, "could not parse container build response", err.Error())
 
 	m.AssertExpectations(t)
 }
 
 func TestParseBuildResponse(t *testing.T) {
-	tag, err := parseBuildResponse(newImageBuildResponse("{\"stream\":\"ok\\n\"}"))
+	err := parseBuildResponse(newImageBuildResponse("{\"stream\":\"ok\\n\"}"))
 	require.NoError(t, err)
-	require.Equal(t, tag, "ok")
 }

--- a/container/build_test.go
+++ b/container/build_test.go
@@ -22,7 +22,7 @@ func newImageBuildResponse(body string) types.ImageBuildResponse {
 
 func TestBuild(t *testing.T) {
 	var (
-		expectedTag = "test:x"
+		expectedTag = "mesg/test:x"
 		options     = types.ImageBuildOptions{
 			Remove:         true,
 			ForceRemove:    true,
@@ -100,7 +100,7 @@ func TestBuildResponseError(t *testing.T) {
 	m.On("ImageBuild", imageBuildArguments...).Once().Return(imageBuildResponse...).Run(imageBuildRun)
 
 	_, err := c.Build(path, "test", "x")
-	require.Equal(t, "image build failed. invalid reference format: repository name must be lowercase", err.Error())
+	require.Equal(t, "image build failed: invalid reference format: repository name must be lowercase", err.Error())
 
 	m.AssertExpectations(t)
 }

--- a/container/container.go
+++ b/container/container.go
@@ -19,7 +19,7 @@ var (
 
 // Container describes the API of container package.
 type Container interface {
-	Build(path string) (tag string, err error)
+	Build(path string, name string, version string) (tag string, err error)
 	CreateNetwork(namespace []string) (id string, err error)
 	DeleteNetwork(namespace []string) error
 	FindContainer(namespace []string) (types.ContainerJSON, error)

--- a/container/mocks/Container.go
+++ b/container/mocks/Container.go
@@ -13,20 +13,20 @@ type Container struct {
 	mock.Mock
 }
 
-// Build provides a mock function with given fields: path
-func (_m *Container) Build(path string) (string, error) {
-	ret := _m.Called(path)
+// Build provides a mock function with given fields: path, name, version
+func (_m *Container) Build(path string, name string, version string) (string, error) {
+	ret := _m.Called(path, name, version)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string) string); ok {
-		r0 = rf(path)
+	if rf, ok := ret.Get(0).(func(string, string, string) string); ok {
+		r0 = rf(path, name, version)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(path)
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(path, name, version)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -128,6 +128,11 @@ func New(tarball io.Reader, env map[string]string, options ...Option) (*Service,
 		return nil, err
 	}
 
+	if s.Sid == "" {
+		// make sure that sid doesn't have the same length with id.
+		s.Sid = "_" + s.Hash
+	}
+
 	// replace default env with new one.
 	defenv := xos.EnvSliceToMap(s.configuration().Env)
 	s.configuration().Env = xos.EnvMapToSlice(xos.EnvMergeMaps(defenv, env))
@@ -192,11 +197,6 @@ func (s *Service) deploy() error {
 	s.sendStatus("Image built with success", DDonePositive)
 
 	s.configuration().Image = imageTag
-	// TODO: the following test should be moved in New function
-	if s.Sid == "" {
-		// make sure that sid doesn't have the same length with id.
-		s.Sid = "_" + s.Hash
-	}
 	return nil
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -184,14 +184,14 @@ func DeployStatusOption(statuses chan DeployStatus) Option {
 func (s *Service) deploy() error {
 	s.sendStatus("Building Docker image...", DRunning)
 
-	imageHash, err := s.container.Build(s.tempPath)
+	imageTag, err := s.container.Build(s.tempPath, s.Sid, s.Hash)
 	if err != nil {
 		return err
 	}
 
 	s.sendStatus("Image built with success", DDonePositive)
 
-	s.configuration().Image = imageHash
+	s.configuration().Image = imageTag
 	// TODO: the following test should be moved in New function
 	if s.Sid == "" {
 		// make sure that sid doesn't have the same length with id.

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -25,7 +25,7 @@ func TestNew(t *testing.T) {
 	)
 
 	mc := &mocks.Container{}
-	mc.On("Build", mock.Anything).Once().Return(hash, nil)
+	mc.On("Build", mock.Anything, mock.Anything, mock.Anything).Once().Return(hash, nil)
 
 	archive, err := xarchive.GzippedTar(path, nil)
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestNewWithDefaultEnv(t *testing.T) {
 	)
 
 	mc := &mocks.Container{}
-	mc.On("Build", mock.Anything).Once().Return(hash, nil)
+	mc.On("Build", mock.Anything, mock.Anything, mock.Anything).Once().Return(hash, nil)
 
 	archive, err := xarchive.GzippedTar(path, nil)
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestNewWithOverwrittenEnv(t *testing.T) {
 	)
 
 	mc := &mocks.Container{}
-	mc.On("Build", mock.Anything).Once().Return(hash, nil)
+	mc.On("Build", mock.Anything, mock.Anything, mock.Anything).Once().Return(hash, nil)
 
 	archive, err := xarchive.GzippedTar(path, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Right now sources are deterministic because based on the source code but the data we save in the database are not because of the `Image` that is the sha of the docker layer and this one is not deterministic.

This PR is a proposal to change the data in the database by saving a tag instead of the id of the docker layer.

- We build the docker image but we tag the output with `sid:hash`
- We save the tag in the database instead of the sha from the docker layer
- We have a service in database that is constant whatever computer/docker version.... 🎉 

These data can now be exchanged on the network and on different computer and so be shared on the marketplace.

Bonus: Now we have some nice informations with `docker images`

<img width="947" alt="Screen Shot 2019-03-29 at 2 24 51 pm" src="https://user-images.githubusercontent.com/1783126/55216119-7e277880-522e-11e9-85e2-5e0755991538.png">
vs
<img width="959" alt="Screen Shot 2019-03-29 at 2 24 58 pm" src="https://user-images.githubusercontent.com/1783126/55216123-7ec00f00-522e-11e9-9688-2aef66cd7796.png">
