### PR TITLE
Stop all dependencies when a service is partially running

### DIFF
--- a/service/start.go
+++ b/service/start.go
@@ -19,7 +19,7 @@ func (s *Service) Start(c container.Container) (serviceIDs []string, err error) 
 	}
 	// If there is one but not all services running stop to restart all
 	if status == PARTIAL {
-		if err := s.StopDependencies(c); err != nil {
+		if err := s.Stop(c); err != nil {
 			return nil, err
 		}
 	}

--- a/service/start_test.go
+++ b/service/start_test.go
@@ -225,6 +225,7 @@ func TestPartiallyRunningService(t *testing.T) {
 	mc.On("StopService", d2.namespace(s.namespace())).Once().Return(nil)
 	mc.On("CreateNetwork", s.namespace()).Once().Return(networkID, nil)
 	mc.On("SharedNetworkID").Twice().Return(sharedNetworkID, nil)
+	mc.On("DeleteNetwork", s.namespace()).Return(nil)
 
 	for i, d := range ds {
 		mockStartService(s, d, mc, networkID, sharedNetworkID, containerServiceIDs[i], nil)


### PR DESCRIPTION
https://github.com/mesg-foundation/core/pull/860#discussion_r273521966

We were using `StopDependencies` because of a side effect on the `DeleteNetwork` and network was not fully deleted and we could not recreate the network again. This bug has been solved so there is no need for this hack and we can just stop everything and restart all