### PR TITLE
api: make New to receive Container as a required param

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -19,29 +19,12 @@ type API struct {
 	container container.Container
 }
 
-// Option is a configuration func for MESG.
-type Option func(*API)
-
 // New creates a new API with given options.
-func New(db database.ServiceDB, execDB database.ExecutionDB, options ...Option) (*API, error) {
-	a := &API{db: db, execDB: execDB}
-	for _, option := range options {
-		option(a)
-	}
-	if a.container == nil {
-		var err error
-		a.container, err = container.New()
-		if err != nil {
-			return nil, err
-		}
-	}
-	return a, nil
-}
-
-// ContainerOption configures underlying container access API.
-func ContainerOption(container container.Container) Option {
-	return func(a *API) {
-		a.container = container
+func New(c container.Container, db database.ServiceDB, execDB database.ExecutionDB) *API {
+	return &API{
+		container: c,
+		db:        db,
+		execDB:    execDB,
 	}
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -40,8 +40,7 @@ func newTesting(t *testing.T) (*API, *apiTesting) {
 	execDB, err := database.NewExecutionDB(execdbname)
 	require.NoError(t, err)
 
-	a, err := New(db, execDB, ContainerOption(containerMock))
-	require.NoError(t, err)
+	a := New(containerMock, db, execDB)
 
 	return a, &apiTesting{
 		T:             t,

--- a/core/main.go
+++ b/core/main.go
@@ -50,10 +50,7 @@ func initDependencies() (*dependencies, error) {
 	}
 
 	// init api.
-	api, err := api.New(serviceDB, executionDB, api.ContainerOption(c))
-	if err != nil {
-		return nil, err
-	}
+	api := api.New(c, serviceDB, executionDB)
 
 	return &dependencies{
 		config:      config,

--- a/interface/grpc/core/test_test.go
+++ b/interface/grpc/core/test_test.go
@@ -31,8 +31,7 @@ func newServerWithContainer(t *testing.T, c container.Container) (*Server, func(
 	execDB, err := database.NewExecutionDB(execdbname)
 	require.NoError(t, err)
 
-	a, err := api.New(db, execDB, api.ContainerOption(c))
-	require.NoError(t, err)
+	a := api.New(c, db, execDB)
 
 	server := NewServer(a)
 

--- a/interface/grpc/service/test_test.go
+++ b/interface/grpc/service/test_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/mesg-foundation/core/api"
+	"github.com/mesg-foundation/core/container"
 	"github.com/mesg-foundation/core/database"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +31,10 @@ func newServer(t *testing.T) (*Server, func()) {
 	execDB, err := database.NewExecutionDB(execdbname)
 	require.NoError(t, err)
 
-	a := api.New(nil, db, execDB)
+	c, err := container.New()
+	require.NoError(t, err)
+
+	a := api.New(c, db, execDB)
 	server := NewServer(a)
 
 	closer := func() {

--- a/interface/grpc/service/test_test.go
+++ b/interface/grpc/service/test_test.go
@@ -30,9 +30,7 @@ func newServer(t *testing.T) (*Server, func()) {
 	execDB, err := database.NewExecutionDB(execdbname)
 	require.NoError(t, err)
 
-	a, err := api.New(db, execDB)
-	require.NoError(t, err)
-
+	a := api.New(nil, db, execDB)
 	server := NewServer(a)
 
 	closer := func() {


### PR DESCRIPTION
* drop support for receving Options as params since there is no need anymore.