### PR TITLE
Improve error message

### DIFF
--- a/interface/grpc/core/core.go
+++ b/interface/grpc/core/core.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/mesg-foundation/core/api"
@@ -188,7 +189,7 @@ func (s *Server) ListenResult(request *coreapi.ListenResultRequest, stream corea
 func (s *Server) ExecuteTask(ctx context.Context, request *coreapi.ExecuteTaskRequest) (*coreapi.ExecuteTaskReply, error) {
 	var inputs map[string]interface{}
 	if err := json.Unmarshal([]byte(request.InputData), &inputs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot parse execution's inputs (JSON format): %s", err)
 	}
 
 	executionID, err := s.api.ExecuteTask(request.ServiceID, request.TaskKey, inputs, request.ExecutionTags)

--- a/interface/grpc/core/core_test.go
+++ b/interface/grpc/core/core_test.go
@@ -160,7 +160,7 @@ func TestExecuteWithInvalidJSON(t *testing.T) {
 		InputData: "",
 	})
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "unexpected end of JSON input")
+	require.Equal(t, err.Error(), "cannot parse execution's inputs (JSON format): unexpected end of JSON input")
 }
 
 func TestExecuteWithInvalidTask(t *testing.T) {


### PR DESCRIPTION
When calling a new execution, the error is not clear if we send an object in the library instead of its json representation.

Just adding some context to the error.