### PR TITLE
fix logs with configuration

### DIFF
--- a/commands/provider/service_provider.go
+++ b/commands/provider/service_provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mesg-foundation/core/commands/provider/assets"
 	"github.com/mesg-foundation/core/protobuf/acknowledgement"
 	"github.com/mesg-foundation/core/protobuf/coreapi"
+	"github.com/mesg-foundation/core/service"
 	"github.com/mesg-foundation/core/service/importer"
 	"github.com/mesg-foundation/core/utils/chunker"
 	"github.com/mesg-foundation/core/utils/pretty"
@@ -117,6 +118,7 @@ func (p *ServiceProvider) ServiceLogs(id string, dependencies ...string) (logs [
 		if err != nil {
 			return nil, nil, nil, err
 		}
+		dependencies = append(dependencies, service.MainServiceKey)
 		for _, dep := range resp.Service.Definition.Dependencies {
 			dependencies = append(dependencies, dep.Key)
 		}

--- a/commands/service_logs.go
+++ b/commands/service_logs.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/mesg-foundation/core/commands/provider"
+	"github.com/mesg-foundation/core/service"
 	"github.com/mesg-foundation/core/utils/pretty"
 	"github.com/mesg-foundation/core/x/xsignal"
 	"github.com/mesg-foundation/core/x/xstrings"
@@ -69,6 +70,7 @@ func showLogs(e ServiceExecutor, serviceID string, dependencies ...string) (clos
 	// if there was no dependencies copy all returned
 	// by service logs.
 	if len(dependencies) == 0 {
+		dependencies = append(dependencies, service.MainServiceKey)
 		for _, log := range logs {
 			dependencies = append(dependencies, log.Dependency)
 		}


### PR DESCRIPTION
Due to the separation of dependencies and configuration, logs were not working anymore.

- Service logs returns the logs from the config if present
- CLI ask for the "service" logs when there is no filter (this could be improved with sending nothing and relying on the api)

fix https://github.com/mesg-foundation/core/issues/878