### PR TITLE
service: fix stop order between service & dependencies

### DIFF
--- a/service/stop.go
+++ b/service/stop.go
@@ -18,7 +18,7 @@ func (s *Service) Stop(c container.Container) error {
 		wg   sync.WaitGroup
 		errs xerrors.SyncErrors
 	)
-	for _, d := range append(s.Dependencies, s.Configuration) {
+	for _, d := range append([]*Dependency{s.Configuration}, s.Dependencies...) {
 		// Service.Configuration can be nil so, here is a check for it.
 		if d == nil {
 			continue


### PR DESCRIPTION
this bug was introduced by #884.

service itself should always be stopped first to give it a chance to properly shutdown itself. if depencies were stopped first, service may try to reconnect them or may start some fault toleration protocols for no reason.