### PR TITLE
Add link to the original source of isDomainName

### DIFF
--- a/x/xnet/dnsclient.go
+++ b/x/xnet/dnsclient.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 package xnet
 
+// Source: https://golang.org/src/net/dnsclient.go
 // IsDomainName checks if a string is a presentation-format domain name
 // (currently restricted to hostname-compatible "preferred name" LDH labels and
 // SRV-like "underscore labels"; see golang.org/issue/12421).


### PR DESCRIPTION
Add link to the original source of `isDomainName` because it was missing and we should be transparent with the origin of the code!

Note: it has been copied because the original is a private function.