### PR TITLE
Fix isAuthorized task by changing a test that check for empty hex

### DIFF
--- a/systemservices/marketplace/src/tasks/isAuthorized.ts
+++ b/systemservices/marketplace/src/tasks/isAuthorized.ts
@@ -16,7 +16,7 @@ export default (
       versionHash = inputs.versionHash
       // get service from version hash
       const sidHash = await contract.methods.versionHashToService(hashToHex(versionHash)).call()
-      if (hexToString(sidHash) === "") {
+      if (Number(sidHash) === 0) {
         throw new Error('service with hash ' + versionHash + ' does not exist')
       }
       const service = await contract.methods.services(sidHash).call()


### PR DESCRIPTION
The function `hexToString` needs a valid utf8 to not throw an error.
It was used to test if the `sidHash` was empty or not. The sidHash is not an utf8 but a keccak.
I replaced it by a conversion to number to make the same test.