### PR TITLE
Force the marketplace timeout to be a number

### DIFF
--- a/systemservices/marketplace/src/index.ts
+++ b/systemservices/marketplace/src/index.ts
@@ -12,7 +12,7 @@ import listenEvents from "./events"
 
 const providerEndpoint = process.env.PROVIDER_ENDPOINT as string
 const marketplaceAddress = process.env.MARKETPLACE_ADDRESS
-const timeout = process.env.TIMEOUT
+const timeout = parseInt(<string>process.env.TIMEOUT, 10)
 const ERC20Address = process.env.TOKEN_ADDRESS
 const blockConfirmations = parseInt(<string>process.env.BLOCK_CONFIRMATIONS, 10)
 const pollingTime = parseInt(<string>process.env.POLLING_TIME, 10)


### PR DESCRIPTION
Force the marketplace timeout to be a number in order to prevent some side effect from web3.