### PR TITLE
Add goproxy to dockerfile of ethwallet

### DIFF
--- a/systemservices/ethwallet/Dockerfile
+++ b/systemservices/ethwallet/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.11.4
 WORKDIR /project
 COPY go.mod go.sum ./
+ENV GOPROXY=https://proxy.golang.org
 RUN go mod download
 COPY . .
 RUN go build ./main.go


### PR DESCRIPTION
Fix https://github.com/mesg-foundation/core/issues/920

Add a `https://proxy.golang.org` as `goproxy` to the dockerfile of etwallet:
```
ENV GOPROXY=https://proxy.golang.org
```

@antho1404 does it solve the build?