### PR TITLE
Marketplace service: Add process.exit in catch of errors that should stop the service

### DIFF
--- a/systemservices/marketplace/src/index.ts
+++ b/systemservices/marketplace/src/index.ts
@@ -34,9 +34,8 @@ const main = async () => {
   console.log('service is ready and running')
 }
 
-try {
-  main()
-    .catch(error => console.error('catch promise', error))
-} catch (error) {
-  console.error('catch try', error)
-}
+main()
+.catch(error => {
+  console.error('catch main', error)
+  process.exit(1)
+})

--- a/systemservices/marketplace/src/tasks/index.ts
+++ b/systemservices/marketplace/src/tasks/index.ts
@@ -15,7 +15,7 @@ import publishPurchase from "./publishPurchase"
 import publishCreateServiceOffer from "./publishCreateServiceOffer"
 import isAuthorized from "./isAuthorized"
 
-export default async (
+export default (
   mesg: Service,
   web3: Web3,
   marketplace: Marketplace,
@@ -35,5 +35,8 @@ export default async (
     publishCreateServiceOffer: publishCreateServiceOffer(web3, marketplace),
     isAuthorized: isAuthorized(marketplace),
   })
-  .on('error', error => console.error('catch listenTask', error))
+  .on('error', error => {
+    console.error('catch listenTask', error)
+    process.exit(1)
+  })
 }


### PR DESCRIPTION
In marketplace service, i got an error in `listenTask` but the service didn't stop and restart.
So tasks were not listen to anymore.

This PR adds a call to `process.exit` in catch of errors that should stop the service

Error:
```
service | catch listenTask { Error: 13 INTERNAL: GOAWAY received
service |     at Object.exports.createStatusError (/app/node_modules/grpc/src/common.js:91:15)
service |     at ClientReadableStream._emitStatusIfDone (/app/node_modules/grpc/src/client.js:233:26)
service |     at ClientReadableStream._receiveStatus (/app/node_modules/grpc/src/client.js:211:8)
service |     at Object.onReceiveStatus (/app/node_modules/grpc/src/client_interceptors.js:1272:15)
service |     at InterceptingListener._callNext (/app/node_modules/grpc/src/client_interceptors.js:568:42)
service |     at InterceptingListener.onReceiveStatus (/app/node_modules/grpc/src/client_interceptors.js:618:8)
service |     at /app/node_modules/grpc/src/client_interceptors.js:1029:24
service |   code: 13,
service |   metadata: Metadata { _internal_repr: {} },
service |   details: 'GOAWAY received' }
```