### PR TITLE
Access services with free offer when no address

### DIFF
--- a/systemservices/marketplace/src/tasks/isAuthorized.ts
+++ b/systemservices/marketplace/src/tasks/isAuthorized.ts
@@ -37,8 +37,13 @@ export default (
 
     await requireServiceExist(contract, sid)
 
+    // Hack to allow user with no address to have access to services with free offers
+    const addresses = inputs.addresses.length > 0
+      ? [...inputs.addresses]
+      : ['0x0000000000000000000000000000000000000000'] // Service with free offer will always return true for whatever address
+
     // check if at least one of the provided addresses is authorized
-    const authorizations = await Promise.all(inputs.addresses.map((address: string) => {
+    const authorizations = await Promise.all(addresses.map((address: string) => {
       return contract.methods.isAuthorized(stringToHex(sid), address).call()
     }) as Promise<boolean>[])
     const authorized = authorizations.reduce((p, c) => p || c, false)


### PR DESCRIPTION
If a service has a free offer, only user of the core with at least one address in the wallet can access it.
This makes sure that even users with no addresses in the wallet can access the service.

This is a bit hacky and a rewrite of this function should be done but it can be done in a better way for a next release